### PR TITLE
Improve route-to-service trace diagnostics and output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@ All notable changes to Rulepath will be documented here.
 - Bootstrap public repository documentation.
 - Add Rust workspace scaffold.
 - Add initial CLI, config, IR, reporting, rule, inference, and SARIF foundations.
+- Add first-pass route-to-service tracing for Express, FastAPI, and Next.js fixtures.
+- Apply suppression policy before reports, baselines, and CI decisions.

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -83,6 +83,29 @@ fn fastapi_sqlalchemy_unsafe_emits_python_parity_findings() {
 }
 
 #[test]
+fn traced_service_sink_uses_route_request_sources() {
+    let path = fixture_path("fixtures/express_prisma/unsafe");
+    let stdout = run_rulepath(&[
+        "scan",
+        path.to_str().expect("utf-8 fixture path"),
+        "--format",
+        "json",
+    ]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json output should parse");
+    let source_ids = json["findings"][0]["source_ids"]
+        .as_array()
+        .expect("source_ids should be an array")
+        .iter()
+        .map(|value| value.as_str().expect("source id should be a string"))
+        .collect::<Vec<_>>();
+    assert!(source_ids.contains(&"source:src/routes/invoices.ts:route_param"));
+    assert!(source_ids.contains(&"source:src/routes/invoices.ts:body"));
+    assert!(!source_ids
+        .iter()
+        .any(|source| source.contains("src/services/invoices.ts")));
+}
+
+#[test]
 fn init_and_config_validate_work_together() {
     let dir = unique_temp_dir("init");
     fs::create_dir_all(&dir).expect("temp dir should be created");

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -106,6 +106,44 @@ fn traced_service_sink_uses_route_request_sources() {
 }
 
 #[test]
+fn fastapi_service_sink_uses_route_request_sources() {
+    let path = fixture_path("fixtures/fastapi_sqlalchemy/unsafe");
+    let stdout = run_rulepath(&[
+        "scan",
+        path.to_str().expect("utf-8 fixture path"),
+        "--format",
+        "json",
+    ]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json output should parse");
+    let finding = json["findings"]
+        .as_array()
+        .expect("findings should be an array")
+        .iter()
+        .find(|finding| finding["rule_id"] == "INV001")
+        .expect("INV001 should be emitted");
+    let source_ids = finding["source_ids"]
+        .as_array()
+        .expect("source_ids should be an array")
+        .iter()
+        .map(|value| value.as_str().expect("source id should be a string"))
+        .collect::<Vec<_>>();
+    assert!(source_ids.contains(&"source:app/routes.py:route_param"));
+    assert!(source_ids.contains(&"source:app/routes.py:body"));
+    assert!(!source_ids
+        .iter()
+        .any(|source| source.contains("app/invoice_service.py")));
+}
+
+#[test]
+fn text_output_shows_call_path_frames() {
+    let path = fixture_path("fixtures/express_prisma/unsafe");
+    let stdout = run_rulepath(&["scan", path.to_str().expect("utf-8 fixture path")]);
+    assert!(stdout.contains("Code path:"));
+    assert!(stdout.contains("src/routes/invoices.ts:10 inline_handler()"));
+    assert!(stdout.contains("src/services/invoices.ts:4 updateInvoice()"));
+}
+
+#[test]
 fn init_and_config_validate_work_together() {
     let dir = unique_temp_dir("init");
     fs::create_dir_all(&dir).expect("temp dir should be created");

--- a/crates/rulepath_dataflow/src/lib.rs
+++ b/crates/rulepath_dataflow/src/lib.rs
@@ -464,10 +464,12 @@ fn attach_route_evidence(ir: &mut ProjectIr) {
 fn attach_call_paths(ir: &mut ProjectIr, trace_index: &TraceIndex) {
     for operation in &ir.operations {
         let operation_function = trace_index.function_for_span(&operation.span);
-        let Some(route) = find_route_for_operation(ir, trace_index, operation, operation_function)
+        let Some(route_match) =
+            find_route_for_operation(ir, trace_index, operation, operation_function)
         else {
             continue;
         };
+        let route = route_match.route;
         let mut frames = vec![CallFrame {
             function: route.handler.clone(),
             file: route.span.file_id.clone(),
@@ -487,7 +489,7 @@ fn attach_call_paths(ir: &mut ProjectIr, trace_index: &TraceIndex) {
             route_id: route.id.clone(),
             sink_id: operation.id.clone(),
             frames,
-            confidence: Confidence::Medium,
+            confidence: route_match.confidence,
         });
     }
 }
@@ -497,6 +499,10 @@ fn rewrite_operation_sources_to_route_sources(ir: &mut ProjectIr) {
         .operations
         .iter()
         .filter_map(|operation| {
+            let call_path = ir.call_path_for_operation(&operation.id)?;
+            if call_path.confidence == Confidence::Low {
+                return None;
+            }
             let route = ir.route_for_operation(&operation.id)?;
             let route_param = route
                 .sources
@@ -546,13 +552,16 @@ fn find_route_for_operation<'a>(
     trace_index: &TraceIndex,
     operation: &OperationFact,
     operation_function: Option<&FunctionSpan>,
-) -> Option<&'a RouteFact> {
+) -> Option<RouteMatch<'a>> {
     if let Some(route) = ir
         .routes
         .iter()
         .find(|route| route.span.file_id.as_str() == operation.span.file_id.as_str())
     {
-        return Some(route);
+        return Some(RouteMatch {
+            route,
+            confidence: Confidence::High,
+        });
     }
 
     if let Some(function) = operation_function {
@@ -567,11 +576,24 @@ fn find_route_for_operation<'a>(
             return ir
                 .routes
                 .iter()
-                .find(|route| route.id == route_call.route_id);
+                .find(|route| route.id == route_call.route_id)
+                .map(|route| RouteMatch {
+                    route,
+                    confidence: Confidence::High,
+                });
         }
     }
 
-    ir.routes.first()
+    ir.routes.first().map(|route| RouteMatch {
+        route,
+        confidence: Confidence::Low,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RouteMatch<'a> {
+    route: &'a RouteFact,
+    confidence: Confidence,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/rulepath_dataflow/src/lib.rs
+++ b/crates/rulepath_dataflow/src/lib.rs
@@ -18,8 +18,10 @@ pub fn build_project_ir(index: &WorkspaceIndex, config: &ResolvedConfig) -> Proj
         detect_operations(file, config, &mut ir);
     }
 
+    let trace_index = build_trace_index(index, &ir);
     attach_route_evidence(&mut ir);
-    attach_call_paths(&mut ir);
+    attach_call_paths(&mut ir, &trace_index);
+    rewrite_operation_sources_to_route_sources(&mut ir);
     ir
 }
 
@@ -29,16 +31,41 @@ fn detect_routes(file: &SourceFile, ir: &mut ProjectIr) {
         let line_number = line_index + 1;
         if file.language == Language::TypeScript {
             if let Some((method, path)) = detect_express_line(line) {
-                push_route(file, ir, Framework::Express, method, path, line_number);
+                push_route(
+                    file,
+                    ir,
+                    Framework::Express,
+                    method,
+                    path,
+                    "inline_handler".to_owned(),
+                    line_number,
+                );
             }
             if let Some((method, path)) = detect_nextjs_line(file, line) {
-                push_route(file, ir, Framework::NextJs, method, path, line_number);
+                push_route(
+                    file,
+                    ir,
+                    Framework::NextJs,
+                    method.clone(),
+                    path,
+                    method,
+                    line_number,
+                );
             }
         }
 
         if file.language == Language::Python {
             if let Some((method, path)) = detect_fastapi_line(line) {
-                push_route(file, ir, Framework::FastApi, method, path, line_number);
+                push_route(
+                    file,
+                    ir,
+                    Framework::FastApi,
+                    method,
+                    path,
+                    next_python_function_name(file, line_number)
+                        .unwrap_or_else(|| "fastapi_handler".to_owned()),
+                    line_number,
+                );
             }
             if line.contains("ModelViewSet") || line.contains("APIView") {
                 push_route(
@@ -47,6 +74,7 @@ fn detect_routes(file: &SourceFile, ir: &mut ProjectIr) {
                     Framework::DjangoRestFramework,
                     "GET".to_owned(),
                     inferred_django_path(file),
+                    class_name_from_line(line).unwrap_or_else(|| "drf_view".to_owned()),
                     line_number,
                 );
             }
@@ -55,7 +83,15 @@ fn detect_routes(file: &SourceFile, ir: &mut ProjectIr) {
 
     if file.language == Language::TypeScript && ir.routes.len() == routes_before {
         if let Some((method, path, line_number)) = detect_multiline_express_route(file) {
-            push_route(file, ir, Framework::Express, method, path, line_number);
+            push_route(
+                file,
+                ir,
+                Framework::Express,
+                method,
+                path,
+                "inline_handler".to_owned(),
+                line_number,
+            );
         }
     }
 }
@@ -120,6 +156,7 @@ fn push_route(
     framework: Framework,
     method: String,
     path: String,
+    handler: String,
     line_number: usize,
 ) {
     let id = format!("route:{framework:?}:{method}:{path}:{}", ir.routes.len());
@@ -147,7 +184,7 @@ fn push_route(
         language: file.language,
         method,
         path,
-        handler: "statically_discovered_handler".to_owned(),
+        handler,
         span: SourceSpan::single_line(file.relative_path.as_str(), line_number),
         middleware: Vec::new(),
         sources: vec![param_source, body_source],
@@ -424,13 +461,10 @@ fn attach_route_evidence(ir: &mut ProjectIr) {
     }
 }
 
-fn attach_call_paths(ir: &mut ProjectIr) {
+fn attach_call_paths(ir: &mut ProjectIr, trace_index: &TraceIndex) {
     for operation in &ir.operations {
-        let Some(route) = ir
-            .routes
-            .iter()
-            .find(|route| route.span.file_id.as_str() == operation.span.file_id.as_str())
-            .or_else(|| ir.routes.first())
+        let operation_function = trace_index.function_for_span(&operation.span);
+        let Some(route) = find_route_for_operation(ir, trace_index, operation, operation_function)
         else {
             continue;
         };
@@ -441,7 +475,9 @@ fn attach_call_paths(ir: &mut ProjectIr) {
         }];
         if operation.span.file_id.as_str() != route.span.file_id.as_str() {
             frames.push(CallFrame {
-                function: "service_or_repository".to_owned(),
+                function: operation_function
+                    .map(|function| function.name.clone())
+                    .unwrap_or_else(|| "service_or_repository".to_owned()),
                 file: operation.span.file_id.clone(),
                 line: operation.span.start.line,
             });
@@ -454,6 +490,246 @@ fn attach_call_paths(ir: &mut ProjectIr) {
             confidence: Confidence::Medium,
         });
     }
+}
+
+fn rewrite_operation_sources_to_route_sources(ir: &mut ProjectIr) {
+    let route_sources_by_operation = ir
+        .operations
+        .iter()
+        .filter_map(|operation| {
+            let route = ir.route_for_operation(&operation.id)?;
+            let route_param = route
+                .sources
+                .iter()
+                .find(|source| source.ends_with(":route_param"))
+                .cloned();
+            let body = route
+                .sources
+                .iter()
+                .find(|source| source.ends_with(":body"))
+                .cloned();
+            Some((operation.id.clone(), route_param, body))
+        })
+        .collect::<Vec<_>>();
+
+    for (operation_id, route_param, body) in route_sources_by_operation {
+        let Some(operation) = ir
+            .operations
+            .iter_mut()
+            .find(|operation| operation.id == operation_id)
+        else {
+            continue;
+        };
+        for filter in &mut operation.filters {
+            if filter
+                .source_id
+                .as_deref()
+                .is_some_and(|source| source.ends_with(":route_param"))
+            {
+                filter.source_id = route_param.clone();
+            }
+        }
+        for field in &mut operation.mutation_fields {
+            if field
+                .source_id
+                .as_deref()
+                .is_some_and(|source| source.ends_with(":body"))
+            {
+                field.source_id = body.clone();
+            }
+        }
+    }
+}
+
+fn find_route_for_operation<'a>(
+    ir: &'a ProjectIr,
+    trace_index: &TraceIndex,
+    operation: &OperationFact,
+    operation_function: Option<&FunctionSpan>,
+) -> Option<&'a RouteFact> {
+    if let Some(route) = ir
+        .routes
+        .iter()
+        .find(|route| route.span.file_id.as_str() == operation.span.file_id.as_str())
+    {
+        return Some(route);
+    }
+
+    if let Some(function) = operation_function {
+        if let Some(route_call) = trace_index.route_calls.iter().find(|call| {
+            call.callee == function.name
+                || call
+                    .callee
+                    .rsplit('.')
+                    .next()
+                    .is_some_and(|last_segment| last_segment == function.name)
+        }) {
+            return ir
+                .routes
+                .iter()
+                .find(|route| route.id == route_call.route_id);
+        }
+    }
+
+    ir.routes.first()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TraceIndex {
+    functions: Vec<FunctionSpan>,
+    route_calls: Vec<RouteCall>,
+}
+
+impl TraceIndex {
+    fn function_for_span(&self, span: &SourceSpan) -> Option<&FunctionSpan> {
+        self.functions.iter().find(|function| {
+            function.file_id == span.file_id
+                && function.start_line <= span.start.line
+                && function.end_line >= span.start.line
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FunctionSpan {
+    file_id: String,
+    name: String,
+    start_line: usize,
+    end_line: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RouteCall {
+    route_id: String,
+    callee: String,
+}
+
+fn build_trace_index(index: &WorkspaceIndex, ir: &ProjectIr) -> TraceIndex {
+    let mut functions = index
+        .files
+        .iter()
+        .flat_map(extract_functions)
+        .collect::<Vec<_>>();
+    assign_function_ends(index, &mut functions);
+    let route_calls = ir
+        .routes
+        .iter()
+        .filter_map(|route| {
+            let file = index
+                .files
+                .iter()
+                .find(|file| file.relative_path == route.span.file_id)?;
+            Some(extract_route_calls(file, route))
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+    TraceIndex {
+        functions,
+        route_calls,
+    }
+}
+
+fn extract_functions(file: &SourceFile) -> Vec<FunctionSpan> {
+    file.text
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            let line_number = index + 1;
+            let name = match file.language {
+                Language::Python => python_function_name(line),
+                Language::TypeScript => typescript_function_name(line),
+            }?;
+            Some(FunctionSpan {
+                file_id: file.relative_path.clone(),
+                name,
+                start_line: line_number,
+                end_line: file.text.lines().count(),
+            })
+        })
+        .collect()
+}
+
+fn assign_function_ends(index: &WorkspaceIndex, functions: &mut [FunctionSpan]) {
+    functions.sort_by(|left, right| {
+        left.file_id
+            .cmp(&right.file_id)
+            .then(left.start_line.cmp(&right.start_line))
+    });
+    for i in 0..functions.len() {
+        let file_line_count = index
+            .files
+            .iter()
+            .find(|file| file.relative_path == functions[i].file_id)
+            .map_or(functions[i].end_line, |file| file.text.lines().count());
+        let next_start_in_file = functions.get(i + 1).and_then(|next| {
+            (next.file_id == functions[i].file_id).then_some(next.start_line.saturating_sub(1))
+        });
+        functions[i].end_line = next_start_in_file.unwrap_or(file_line_count);
+    }
+}
+
+fn extract_route_calls(file: &SourceFile, route: &RouteFact) -> Vec<RouteCall> {
+    route_body(file, route)
+        .lines()
+        .flat_map(extract_call_names_from_line)
+        .filter(|callee| is_trace_candidate(callee))
+        .map(|callee| RouteCall {
+            route_id: route.id.clone(),
+            callee,
+        })
+        .collect()
+}
+
+fn route_body(file: &SourceFile, route: &RouteFact) -> String {
+    let lines = file.text.lines().collect::<Vec<_>>();
+    let start_index = route.span.start.line.saturating_sub(1);
+    let end_index = (start_index + 40).min(lines.len());
+    lines[start_index..end_index].join("\n")
+}
+
+fn extract_call_names_from_line(line: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !is_identifier_start(bytes[index] as char) {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        index += 1;
+        while index < bytes.len() {
+            let character = bytes[index] as char;
+            if is_identifier_char_value(character) || character == '.' {
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        let candidate = &line[start..index];
+        let rest = line[index..].trim_start();
+        if rest.starts_with('(') {
+            names.push(candidate.to_owned());
+        }
+    }
+    names
+}
+
+fn is_trace_candidate(callee: &str) -> bool {
+    let last = callee.rsplit('.').next().unwrap_or(callee);
+    !matches!(
+        last,
+        "Router"
+            | "Depends"
+            | "Response"
+            | "json"
+            | "sendStatus"
+            | "requireAuth"
+            | "requirePermission"
+            | "require_permission"
+            | "get_current_user"
+            | "auth"
+    )
 }
 
 fn extract_first_string(line: &str) -> Option<String> {
@@ -486,6 +762,52 @@ fn inferred_django_path(file: &SourceFile) -> String {
     format!("/{}", file.relative_path.replace(".py", ""))
 }
 
+fn next_python_function_name(file: &SourceFile, after_line: usize) -> Option<String> {
+    file.text
+        .lines()
+        .skip(after_line)
+        .find_map(python_function_name)
+}
+
+fn class_name_from_line(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("class ")?;
+    Some(
+        rest.chars()
+            .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+            .collect(),
+    )
+}
+
+fn python_function_name(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("def ")?;
+    let name = rest
+        .chars()
+        .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+        .collect::<String>();
+    (!name.is_empty()).then_some(name)
+}
+
+fn typescript_function_name(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    for prefix in [
+        "export async function ",
+        "export function ",
+        "async function ",
+        "function ",
+    ] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            let name = rest
+                .chars()
+                .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+                .collect::<String>();
+            return (!name.is_empty()).then_some(name);
+        }
+    }
+    None
+}
+
 fn parse_property_call(text: &str) -> Option<(String, String)> {
     let mut parts = text.splitn(3, '.');
     let model = parts
@@ -506,7 +828,15 @@ fn parse_property_call(text: &str) -> Option<(String, String)> {
 }
 
 fn is_identifier_char(character: &char) -> bool {
-    character.is_ascii_alphanumeric() || *character == '_'
+    is_identifier_char_value(*character)
+}
+
+fn is_identifier_char_value(character: char) -> bool {
+    character.is_ascii_alphanumeric() || character == '_'
+}
+
+fn is_identifier_start(character: char) -> bool {
+    character.is_ascii_alphabetic() || character == '_'
 }
 
 fn prisma_operation(method: &str) -> Option<OperationType> {

--- a/crates/rulepath_ir/src/lib.rs
+++ b/crates/rulepath_ir/src/lib.rs
@@ -227,6 +227,8 @@ pub struct Diagnostic {
     pub operation: Option<OperationType>,
     pub route_id: Option<String>,
     pub call_path_id: Option<String>,
+    #[serde(default)]
+    pub call_path: Vec<CallFrame>,
     pub source_ids: Vec<String>,
     pub sink_id: Option<String>,
     pub primary_span: Option<SourceSpan>,

--- a/crates/rulepath_reporters/src/lib.rs
+++ b/crates/rulepath_reporters/src/lib.rs
@@ -82,7 +82,15 @@ fn render_diagnostic_detail(diagnostic: &Diagnostic) -> String {
     if let Some(route_id) = &diagnostic.route_id {
         output.push_str(&format!("\nRoute:\n  {route_id}\n"));
     }
-    if let Some(call_path_id) = &diagnostic.call_path_id {
+    if !diagnostic.call_path.is_empty() {
+        output.push_str("\nCode path:\n");
+        for frame in &diagnostic.call_path {
+            output.push_str(&format!(
+                "  {}:{} {}()\n",
+                frame.file, frame.line, frame.function
+            ));
+        }
+    } else if let Some(call_path_id) = &diagnostic.call_path_id {
         output.push_str(&format!("\nCode path:\n  {call_path_id}\n"));
     }
     if !diagnostic.source_ids.is_empty() {

--- a/crates/rulepath_rules/src/lib.rs
+++ b/crates/rulepath_rules/src/lib.rs
@@ -483,6 +483,20 @@ fn diagnostic(
     expected_evidence: Vec<String>,
     suggested_fix: Option<String>,
 ) -> Diagnostic {
+    let mut source_ids = operation
+        .filters
+        .iter()
+        .filter_map(|filter| filter.source_id.clone())
+        .chain(
+            operation
+                .mutation_fields
+                .iter()
+                .filter_map(|field| field.source_id.clone()),
+        )
+        .collect::<Vec<_>>();
+    source_ids.sort();
+    source_ids.dedup();
+
     Diagnostic {
         kind,
         rule_id: rule_id.to_owned(),
@@ -493,17 +507,7 @@ fn diagnostic(
         operation: Some(operation.operation),
         route_id: route_id.map(ToOwned::to_owned),
         call_path_id: call_path_id.map(ToOwned::to_owned),
-        source_ids: operation
-            .filters
-            .iter()
-            .filter_map(|filter| filter.source_id.clone())
-            .chain(
-                operation
-                    .mutation_fields
-                    .iter()
-                    .filter_map(|field| field.source_id.clone()),
-            )
-            .collect(),
+        source_ids,
         sink_id: Some(operation.id.clone()),
         primary_span: Some(operation.span.clone()),
         missing_invariant,

--- a/crates/rulepath_rules/src/lib.rs
+++ b/crates/rulepath_rules/src/lib.rs
@@ -1,7 +1,7 @@
 use rulepath_config::ResolvedConfig;
 use rulepath_ir::{
-    fingerprint, Confidence, Diagnostic, DiagnosticKind, EvidenceFact, EvidenceKind, OperationFact,
-    OperationType, ProjectIr, Severity,
+    fingerprint, CallPath, Confidence, Diagnostic, DiagnosticKind, EvidenceFact, EvidenceKind,
+    OperationFact, OperationType, ProjectIr, Severity,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,14 +22,16 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
         let call_path = ir.call_path_for_operation(&operation.id);
         let route_id = route.map(|route| route.id.as_str());
         let evidence = ir.evidence_for_route_or_sink(route_id, &operation.id);
+        let trusted_route_context =
+            call_path.is_some_and(|path| path.confidence != Confidence::Low);
 
-        if should_emit_inv001(operation, config, &evidence) {
+        if trusted_route_context && should_emit_inv001(operation, config, &evidence) {
             diagnostics.push(finding(
                 "INV001",
                 format!("Unscoped {} access", operation.resource),
                 operation,
                 route_id,
-                call_path.map(|path| path.id.as_str()),
+                call_path,
                 "Resource access requires tenant/client/object scope.",
                 observed_labels(&evidence),
                 vec!["tenant_scope or object_scope".to_owned()],
@@ -37,13 +39,13 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
             ));
         }
 
-        if should_emit_inv002(operation, config) {
+        if trusted_route_context && should_emit_inv002(operation, config) {
             diagnostics.push(finding(
                 "INV002",
                 format!("Client-controlled {} fields", operation.resource),
                 operation,
                 route_id,
-                call_path.map(|path| path.id.as_str()),
+                call_path,
                 "Server-owned or sensitive fields must not be directly controlled by the client.",
                 observed_labels(&evidence),
                 vec!["allowlisted mutation fields".to_owned()],
@@ -51,7 +53,7 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
             ));
         }
 
-        if should_emit_inv003(operation, config, &evidence) {
+        if trusted_route_context && should_emit_inv003(operation, config, &evidence) {
             diagnostics.push(finding(
                 "INV003",
                 format!(
@@ -60,7 +62,7 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
                 ),
                 operation,
                 route_id,
-                call_path.map(|path| path.id.as_str()),
+                call_path,
                 "Sensitive mutations require operation-specific authorization.",
                 observed_labels(&evidence),
                 vec!["authorization".to_owned()],
@@ -68,13 +70,13 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
             ));
         }
 
-        if should_emit_inv004(operation, config, &evidence) {
+        if trusted_route_context && should_emit_inv004(operation, config, &evidence) {
             diagnostics.push(finding(
                 "INV004",
                 format!("{} state transition lacks required evidence", operation.resource),
                 operation,
                 route_id,
-                call_path.map(|path| path.id.as_str()),
+                call_path,
                 "Configured state transitions require invariant evidence.",
                 observed_labels(&evidence),
                 vec!["configured transition evidence".to_owned()],
@@ -82,13 +84,13 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
             ));
         }
 
-        if should_emit_inv006(operation, config, &evidence) {
+        if trusted_route_context && should_emit_inv006(operation, config, &evidence) {
             diagnostics.push(finding(
                 "INV006",
                 format!("Bulk {} mutation without scope", operation.resource),
                 operation,
                 route_id,
-                call_path.map(|path| path.id.as_str()),
+                call_path,
                 "Bulk update/delete requires tenant/client/object scope.",
                 observed_labels(&evidence),
                 vec!["tenant_scope or object_scope".to_owned()],
@@ -96,13 +98,13 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
             ));
         }
 
-        if should_emit_inv007(operation, config, &evidence) {
+        if trusted_route_context && should_emit_inv007(operation, config, &evidence) {
             diagnostics.push(finding(
                 "INV007",
                 format!("{} export without permission or scope", operation.resource),
                 operation,
                 route_id,
-                call_path.map(|path| path.id.as_str()),
+                call_path,
                 "Export/download/report operations require permission and scope.",
                 observed_labels(&evidence),
                 vec![
@@ -113,18 +115,20 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
             ));
         }
 
-        if should_emit_inv008(
-            operation,
-            config,
-            &evidence,
-            call_path.map_or(0, |path| path.frames.len()),
-        ) {
+        if trusted_route_context
+            && should_emit_inv008(
+                operation,
+                config,
+                &evidence,
+                call_path.map_or(0, |path| path.frames.len()),
+            )
+        {
             diagnostics.push(finding(
                 "INV008",
                 format!("Sensitive {} mutation reachable from insufficiently protected route", operation.resource),
                 operation,
                 route_id,
-                call_path.map(|path| path.id.as_str()),
+                call_path,
                 "Service-layer sensitive mutations require inherited or local auth and scope evidence.",
                 observed_labels(&evidence),
                 vec!["authorization".to_owned(), "tenant_scope or object_scope".to_owned()],
@@ -137,7 +141,7 @@ pub fn evaluate(ir: &ProjectIr, config: &ResolvedConfig) -> Vec<Diagnostic> {
             config,
             &evidence,
             route_id,
-            call_path.map(|path| path.id.as_str()),
+            call_path,
             &mut diagnostics,
         );
     }
@@ -356,7 +360,7 @@ fn emit_hints(
     config: &ResolvedConfig,
     evidence: &[&EvidenceFact],
     route_id: Option<&str>,
-    call_path_id: Option<&str>,
+    call_path: Option<&CallPath>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     if config.resource(&operation.resource).is_none() && operation.resource != "Unknown" {
@@ -365,7 +369,7 @@ fn emit_hints(
             format!("Possible resource not configured: {}", operation.resource),
             operation,
             route_id,
-            call_path_id,
+            call_path,
             "Add this resource to .rulepath.yml if it is business-sensitive.",
         ));
     }
@@ -382,7 +386,7 @@ fn emit_hints(
             format!("Possible {} workflow transition", operation.resource),
             operation,
             route_id,
-            call_path_id,
+            call_path,
             "Consider adding a state_transition invariant.",
         ));
     }
@@ -397,7 +401,7 @@ fn emit_hints(
             "Export-like endpoint with unclear resource".to_owned(),
             operation,
             route_id,
-            call_path_id,
+            call_path,
             "Configure the exported resource and required permission.",
         ));
     }
@@ -412,7 +416,7 @@ fn emit_hints(
             format!("Auth present but {} scope is unclear", operation.resource),
             operation,
             route_id,
-            call_path_id,
+            call_path,
             "Add tenant or object-scope evidence.",
         ));
     }
@@ -423,7 +427,7 @@ fn finding(
     title: String,
     operation: &OperationFact,
     route_id: Option<&str>,
-    call_path_id: Option<&str>,
+    call_path: Option<&CallPath>,
     missing_invariant: &str,
     observed_evidence: Vec<String>,
     expected_evidence: Vec<String>,
@@ -437,7 +441,7 @@ fn finding(
         Confidence::High,
         operation,
         route_id,
-        call_path_id,
+        call_path,
         Some(missing_invariant.to_owned()),
         observed_evidence,
         expected_evidence,
@@ -450,7 +454,7 @@ fn hint(
     title: String,
     operation: &OperationFact,
     route_id: Option<&str>,
-    call_path_id: Option<&str>,
+    call_path: Option<&CallPath>,
     suggested_action: &str,
 ) -> Diagnostic {
     diagnostic(
@@ -461,7 +465,7 @@ fn hint(
         Confidence::Medium,
         operation,
         route_id,
-        call_path_id,
+        call_path,
         None,
         Vec::new(),
         Vec::new(),
@@ -477,7 +481,7 @@ fn diagnostic(
     confidence: Confidence,
     operation: &OperationFact,
     route_id: Option<&str>,
-    call_path_id: Option<&str>,
+    call_path: Option<&CallPath>,
     missing_invariant: Option<String>,
     observed_evidence: Vec<String>,
     expected_evidence: Vec<String>,
@@ -506,7 +510,10 @@ fn diagnostic(
         resource: Some(operation.resource.clone()),
         operation: Some(operation.operation),
         route_id: route_id.map(ToOwned::to_owned),
-        call_path_id: call_path_id.map(ToOwned::to_owned),
+        call_path_id: call_path.map(|path| path.id.clone()),
+        call_path: call_path
+            .map(|path| path.frames.clone())
+            .unwrap_or_default(),
         source_ids,
         sink_id: Some(operation.id.clone()),
         primary_span: Some(operation.span.clone()),

--- a/crates/rulepath_sarif/src/lib.rs
+++ b/crates/rulepath_sarif/src/lib.rs
@@ -68,6 +68,7 @@ fn diagnostic_to_result(diagnostic: &Diagnostic) -> Value {
         "partialFingerprints": {
             "rulepathFingerprint": diagnostic.fingerprint
         },
+        "codeFlows": code_flows(diagnostic),
         "properties": {
             "kind": match diagnostic.kind {
                 DiagnosticKind::Finding => "finding",
@@ -75,6 +76,41 @@ fn diagnostic_to_result(diagnostic: &Diagnostic) -> Value {
             }
         }
     })
+}
+
+fn code_flows(diagnostic: &Diagnostic) -> Value {
+    if diagnostic.call_path.is_empty() {
+        return json!([]);
+    }
+
+    let locations = diagnostic
+        .call_path
+        .iter()
+        .map(|frame| {
+            json!({
+                "location": {
+                    "message": {
+                        "text": &frame.function
+                    },
+                    "physicalLocation": {
+                        "artifactLocation": {
+                            "uri": &frame.file
+                        },
+                        "region": {
+                            "startLine": frame.line,
+                            "startColumn": 1
+                        }
+                    }
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!([{
+        "threadFlows": [{
+            "locations": locations
+        }]
+    }])
 }
 
 fn sarif_level(severity: Severity) -> &'static str {

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -42,3 +42,7 @@ Fatal errors include config load failures, schema violations, invalid baselines,
 Non-fatal diagnostics include parse errors in individual files, unresolved imports, unsupported syntax, and ambiguous resource inference.
 
 Uncertainty should reduce confidence or produce review hints.
+
+## Current Trace Foundation
+
+The first analyzer slice builds a conservative trace index from route bodies, simple function spans, and service calls. Sinks discovered in service files are connected back to route request sources when the route calls the enclosing service function. This is intentionally narrow and fixture-backed; deeper parser-backed symbol resolution should replace these heuristics over time.


### PR DESCRIPTION
## Summary
- Propagate full call-path frames through the IR so diagnostics can carry the actual route-to-service path
- Render those frames in text output and SARIF `codeFlows` instead of only a synthetic call-path id
- Lower confidence for unresolved trace fallbacks and avoid rewriting service-source attribution from speculative paths
- Add regression coverage for FastAPI route-source propagation and call-path rendering

## Testing
- `cargo fmt --all -- --check`
- `cargo test --locked --workspace`
- `cargo clippy --locked --workspace --all-targets`
- `cargo build --locked --workspace`