### PR TITLE
Implement phase 1 foundation parser and registry pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,44 +544,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3b8bfef454857d3d9ca08fb84c8955da8591b5a82a21bb34a7ebbf94da7b0f"
-dependencies = [
- "allocator-api2",
- "hashbrown 0.17.0",
- "oxc_data_structures 0.127.0",
- "rustc-hash",
-]
-
-[[package]]
-name = "oxc_allocator"
 version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b554cc48bdde5684b8a2bf3355524694ee47d9de4246eaf6199b8aecfd952cb"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.0",
- "oxc_data_structures 0.128.0",
+ "oxc_data_structures",
  "rustc-hash",
-]
-
-[[package]]
-name = "oxc_ast"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381ae8356082431bd7e217dd78c7179bfc379dbbe7a32494e28be4fc678812c7"
-dependencies = [
- "bitflags",
- "oxc_allocator 0.127.0",
- "oxc_ast_macros 0.127.0",
- "oxc_data_structures 0.127.0",
- "oxc_diagnostics 0.127.0",
- "oxc_estree 0.127.0",
- "oxc_regular_expression 0.127.0",
- "oxc_span 0.127.0",
- "oxc_str 0.127.0",
- "oxc_syntax 0.127.0",
 ]
 
 [[package]]
@@ -591,27 +561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d027d8f8b23257e1711e0db8b80c9dacb3ab567a3357b4560eaa1d0a04da2d30"
 dependencies = [
  "bitflags",
- "oxc_allocator 0.128.0",
- "oxc_ast_macros 0.128.0",
- "oxc_data_structures 0.128.0",
- "oxc_diagnostics 0.128.0",
- "oxc_estree 0.128.0",
- "oxc_regular_expression 0.128.0",
- "oxc_span 0.128.0",
- "oxc_str 0.128.0",
- "oxc_syntax 0.128.0",
-]
-
-[[package]]
-name = "oxc_ast_macros"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50246449a5fa669debd2debeb90be4c30f0a3a2e954f852ec40e5ef49701285"
-dependencies = [
- "phf",
- "proc-macro2",
- "quote",
- "syn",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
 ]
 
 [[package]]
@@ -628,26 +586,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1defc2fd17ee94f2c8511b0c4a4756d5868fbee891478953f2354ef444b1962f"
-
-[[package]]
-name = "oxc_data_structures"
 version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c425cdc1a05603d9b6d13786892d69364a0c18de06ffa511109a9e0a760b423c"
-
-[[package]]
-name = "oxc_diagnostics"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7ccb0e8e7c9f1fb75e0700b2c75d9d854e534a7a356b13d2936893651f2b98"
-dependencies = [
- "cow-utils",
- "oxc-miette",
- "percent-encoding",
-]
 
 [[package]]
 name = "oxc_diagnostics"
@@ -669,18 +610,12 @@ dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.128.0",
- "oxc_ast 0.128.0",
- "oxc_regular_expression 0.128.0",
- "oxc_span 0.128.0",
- "oxc_syntax 0.128.0",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
 ]
-
-[[package]]
-name = "oxc_estree"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87cd0e290bab4cb5d81377bbc1ebd414f01a7af72d7f8e5ccbb4a9a157d71df"
 
 [[package]]
 name = "oxc_estree"
@@ -709,34 +644,17 @@ dependencies = [
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.128.0",
- "oxc_ast 0.128.0",
- "oxc_data_structures 0.128.0",
- "oxc_diagnostics 0.128.0",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
  "oxc_ecmascript",
- "oxc_regular_expression 0.128.0",
- "oxc_span 0.128.0",
- "oxc_str 0.128.0",
- "oxc_syntax 0.128.0",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
  "rustc-hash",
  "seq-macro",
-]
-
-[[package]]
-name = "oxc_regular_expression"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a1273168ec6d8083e161565d264847249b9aad51c430d92d344303ede058b2"
-dependencies = [
- "bitflags",
- "oxc_allocator 0.127.0",
- "oxc_ast_macros 0.127.0",
- "oxc_diagnostics 0.127.0",
- "oxc_span 0.127.0",
- "oxc_str 0.127.0",
- "phf",
- "rustc-hash",
- "unicode-id-start",
 ]
 
 [[package]]
@@ -746,28 +664,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e92ddddf8645910675528f66b3159c018c553fa47e4644514513705f5d3c22b"
 dependencies = [
  "bitflags",
- "oxc_allocator 0.128.0",
- "oxc_ast_macros 0.128.0",
- "oxc_diagnostics 0.128.0",
- "oxc_span 0.128.0",
- "oxc_str 0.128.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "oxc_str",
  "phf",
  "rustc-hash",
  "unicode-id-start",
-]
-
-[[package]]
-name = "oxc_span"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af84474452c3caa7aca1bcaca04b6e16552fe29472059b7921ae7a69790dccf"
-dependencies = [
- "compact_str",
- "oxc-miette",
- "oxc_allocator 0.127.0",
- "oxc_ast_macros 0.127.0",
- "oxc_estree 0.127.0",
- "oxc_str 0.127.0",
 ]
 
 [[package]]
@@ -778,22 +682,10 @@ checksum = "f03b54ae4c2254ffdbba43f82e4ea097182b300d2f3ccd1f81f8ca145556e659"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc_allocator 0.128.0",
- "oxc_ast_macros 0.128.0",
- "oxc_estree 0.128.0",
- "oxc_str 0.128.0",
-]
-
-[[package]]
-name = "oxc_str"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136bcc6bed1182df0b9c529e478da55a490b38ba5f1189abf2e7a9b13f46f0b1"
-dependencies = [
- "compact_str",
- "hashbrown 0.17.0",
- "oxc_allocator 0.127.0",
- "oxc_estree 0.127.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
 ]
 
 [[package]]
@@ -804,27 +696,8 @@ checksum = "686c0fe58e5a4a3698921871fbe23043ac271cf324540591dfcc5e7d0f127a5a"
 dependencies = [
  "compact_str",
  "hashbrown 0.17.0",
- "oxc_allocator 0.128.0",
- "oxc_estree 0.128.0",
-]
-
-[[package]]
-name = "oxc_syntax"
-version = "0.127.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b448a086623714675f66b79271e25fa2b51708255fa6af7dad83be88cc6e8726"
-dependencies = [
- "bitflags",
- "cow-utils",
- "nonmax",
- "oxc_allocator 0.127.0",
- "oxc_ast_macros 0.127.0",
- "oxc_estree 0.127.0",
- "oxc_index",
- "oxc_span 0.127.0",
- "oxc_str 0.127.0",
- "phf",
- "unicode-id-start",
+ "oxc_allocator",
+ "oxc_estree",
 ]
 
 [[package]]
@@ -837,12 +710,12 @@ dependencies = [
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator 0.128.0",
- "oxc_ast_macros 0.128.0",
- "oxc_estree 0.128.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
  "oxc_index",
- "oxc_span 0.128.0",
- "oxc_str 0.128.0",
+ "oxc_span",
+ "oxc_str",
  "phf",
  "unicode-id-start",
 ]
@@ -1075,8 +948,10 @@ dependencies = [
 name = "rulepath_lang_typescript"
 version = "0.1.0"
 dependencies = [
- "oxc_ast 0.127.0",
+ "oxc_allocator",
+ "oxc_ast",
  "oxc_parser",
+ "oxc_span",
  "rulepath_ir",
  "rulepath_parsers",
  "rulepath_workspace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,12 @@ version = "0.1.0"
 dependencies = [
  "petgraph",
  "rulepath_config",
+ "rulepath_frameworks",
  "rulepath_ir",
+ "rulepath_lang_python",
+ "rulepath_lang_typescript",
+ "rulepath_orms",
+ "rulepath_parsers",
  "rulepath_workspace",
 ]
 
@@ -914,6 +919,7 @@ version = "0.1.0"
 dependencies = [
  "rulepath_ir",
  "rulepath_parsers",
+ "rulepath_workspace",
 ]
 
 [[package]]
@@ -961,8 +967,10 @@ dependencies = [
 name = "rulepath_orms"
 version = "0.1.0"
 dependencies = [
+ "rulepath_config",
  "rulepath_ir",
  "rulepath_parsers",
+ "rulepath_workspace",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,10 @@ clap = { version = "=4.6.1", features = ["derive"] }
 ignore = "=0.4.25"
 lasso = "=0.7.3"
 miette = { version = "=7.6.0", features = ["fancy"] }
-oxc_ast = "=0.127.0"
+oxc_allocator = "=0.128.0"
+oxc_ast = "=0.128.0"
 oxc_parser = "=0.128.0"
+oxc_span = "=0.128.0"
 petgraph = "=0.8.3"
 rayon = "=1.12.0"
 schemars = { version = "=1.2.1", features = ["derive"] }

--- a/crates/rulepath_dataflow/Cargo.toml
+++ b/crates/rulepath_dataflow/Cargo.toml
@@ -10,7 +10,12 @@ description = "Route-to-sink tracing and initial IR construction for Rulepath."
 [dependencies]
 petgraph.workspace = true
 rulepath_config = { path = "../rulepath_config" }
+rulepath_frameworks = { path = "../rulepath_frameworks" }
 rulepath_ir = { path = "../rulepath_ir" }
+rulepath_lang_python = { path = "../rulepath_lang_python" }
+rulepath_lang_typescript = { path = "../rulepath_lang_typescript" }
+rulepath_orms = { path = "../rulepath_orms" }
+rulepath_parsers = { path = "../rulepath_parsers" }
 rulepath_workspace = { path = "../rulepath_workspace" }
 
 [lints]

--- a/crates/rulepath_dataflow/src/lib.rs
+++ b/crates/rulepath_dataflow/src/lib.rs
@@ -1,448 +1,96 @@
 use rulepath_config::ResolvedConfig;
 use rulepath_ir::{
-    CallFrame, CallPath, Confidence, DataLayer, EvidenceFact, EvidenceKind, FilterFact, Framework,
-    Language, MutationFieldFact, OperationFact, OperationType, ProjectIr, RouteFact, SourceFact,
-    SourceKind, SourceSpan,
+    CallFrame, CallPath, Confidence, OperationFact, ProjectIr, RouteFact, SourceSpan,
 };
-use rulepath_workspace::{line_number_for_offset, SourceFile, WorkspaceIndex};
+use rulepath_parsers::{LanguageAdapter, ParsedFile, SymbolKind};
+use rulepath_workspace::WorkspaceIndex;
+
+pub struct ScanContext<'a> {
+    pub index: &'a WorkspaceIndex,
+    pub parsed_files: Vec<ParsedFile>,
+    pub ir: ProjectIr,
+}
 
 pub fn build_project_ir(index: &WorkspaceIndex, config: &ResolvedConfig) -> ProjectIr {
-    let mut ir = ProjectIr::default();
+    let mut context = ScanContext {
+        index,
+        parsed_files: parse_workspace(index),
+        ir: ProjectIr::default(),
+    };
 
-    for file in &index.files {
-        detect_routes(file, &mut ir);
-    }
+    collect_framework_and_auth_facts(&mut context);
+    collect_operation_facts(&mut context, config);
 
-    for file in &index.files {
-        detect_evidence(file, &mut ir);
-        detect_operations(file, config, &mut ir);
-    }
-
-    let trace_index = build_trace_index(index, &ir);
-    attach_route_evidence(&mut ir);
-    attach_call_paths(&mut ir, &trace_index);
-    rewrite_operation_sources_to_route_sources(&mut ir);
-    ir
+    let trace_index = build_trace_index(context.index, &context.parsed_files, &context.ir);
+    attach_route_evidence(&mut context.ir);
+    attach_call_paths(&mut context.ir, &trace_index);
+    rewrite_operation_sources_to_route_sources(&mut context.ir);
+    sort_project_ir(&mut context.ir);
+    context.ir
 }
 
-fn detect_routes(file: &SourceFile, ir: &mut ProjectIr) {
-    let routes_before = ir.routes.len();
-    for (line_index, line) in file.text.lines().enumerate() {
-        let line_number = line_index + 1;
-        if file.language == Language::TypeScript {
-            if let Some((method, path)) = detect_express_line(line) {
-                push_route(
-                    file,
-                    ir,
-                    Framework::Express,
-                    method,
-                    path,
-                    "inline_handler".to_owned(),
-                    line_number,
-                );
-            }
-            if let Some((method, path)) = detect_nextjs_line(file, line) {
-                push_route(
-                    file,
-                    ir,
-                    Framework::NextJs,
-                    method.clone(),
-                    path,
-                    method,
-                    line_number,
-                );
-            }
-        }
-
-        if file.language == Language::Python {
-            if let Some((method, path)) = detect_fastapi_line(line) {
-                push_route(
-                    file,
-                    ir,
-                    Framework::FastApi,
-                    method,
-                    path,
-                    next_python_function_name(file, line_number)
-                        .unwrap_or_else(|| "fastapi_handler".to_owned()),
-                    line_number,
-                );
-            }
-            if line.contains("ModelViewSet") || line.contains("APIView") {
-                push_route(
-                    file,
-                    ir,
-                    Framework::DjangoRestFramework,
-                    "GET".to_owned(),
-                    inferred_django_path(file),
-                    class_name_from_line(line).unwrap_or_else(|| "drf_view".to_owned()),
-                    line_number,
-                );
-            }
-        }
-    }
-
-    if file.language == Language::TypeScript && ir.routes.len() == routes_before {
-        if let Some((method, path, line_number)) = detect_multiline_express_route(file) {
-            push_route(
-                file,
-                ir,
-                Framework::Express,
-                method,
-                path,
-                "inline_handler".to_owned(),
-                line_number,
-            );
-        }
-    }
-}
-
-fn detect_express_line(line: &str) -> Option<(String, String)> {
-    for method in ["get", "post", "put", "patch", "delete"] {
-        let router_call = format!("router.{method}(");
-        let app_call = format!("app.{method}(");
-        if line.contains(&router_call) || line.contains(&app_call) {
-            return Some((method.to_ascii_uppercase(), extract_first_string(line)?));
-        }
-    }
-    None
-}
-
-fn detect_fastapi_line(line: &str) -> Option<(String, String)> {
-    let trimmed = line.trim_start();
-    if !(trimmed.starts_with("@router.") || trimmed.starts_with("@app.")) {
-        return None;
-    }
-    for method in ["get", "post", "put", "patch", "delete"] {
-        if trimmed.contains(&format!(".{method}(")) {
-            return Some((method.to_ascii_uppercase(), extract_first_string(trimmed)?));
-        }
-    }
-    None
-}
-
-fn detect_nextjs_line(file: &SourceFile, line: &str) -> Option<(String, String)> {
-    if !file.relative_path.contains("app/api/") && !file.relative_path.contains("pages/api/") {
-        return None;
-    }
-    for method in ["GET", "POST", "PUT", "PATCH", "DELETE"] {
-        if line.contains(&format!("function {method}")) || line.contains(&format!("const {method}"))
-        {
-            return Some((
-                method.to_owned(),
-                path_from_nextjs_file(file.relative_path.as_str()),
-            ));
-        }
-    }
-    None
-}
-
-fn detect_multiline_express_route(file: &SourceFile) -> Option<(String, String, usize)> {
-    for method in ["get", "post", "put", "patch", "delete"] {
-        for needle in [format!("router.{method}("), format!("app.{method}(")] {
-            if let Some((offset, _)) = file.text.match_indices(&needle).next() {
-                let window = surrounding_window(&file.text, offset, 300);
-                let path = extract_first_string(&window)?;
-                let line = line_number_for_offset(&file.text, offset);
-                return Some((method.to_ascii_uppercase(), path, line));
-            }
-        }
-    }
-    None
-}
-
-fn push_route(
-    file: &SourceFile,
-    ir: &mut ProjectIr,
-    framework: Framework,
-    method: String,
-    path: String,
-    handler: String,
-    line_number: usize,
-) {
-    let id = format!("route:{framework:?}:{method}:{path}:{}", ir.routes.len());
-    let body_source = format!("source:{}:body", file.relative_path);
-    let param_source = format!("source:{}:route_param", file.relative_path);
-    ir.sources.push(SourceFact {
-        id: body_source.clone(),
-        kind: SourceKind::Body,
-        name: "body".to_owned(),
-        expression: body_expression(framework),
-        controlled_by_request: true,
-        span: SourceSpan::single_line(file.relative_path.as_str(), line_number),
-    });
-    ir.sources.push(SourceFact {
-        id: param_source.clone(),
-        kind: SourceKind::RouteParam,
-        name: "id".to_owned(),
-        expression: param_expression(framework),
-        controlled_by_request: true,
-        span: SourceSpan::single_line(file.relative_path.as_str(), line_number),
-    });
-    ir.routes.push(RouteFact {
-        id,
-        framework,
-        language: file.language,
-        method,
-        path,
-        handler,
-        span: SourceSpan::single_line(file.relative_path.as_str(), line_number),
-        middleware: Vec::new(),
-        sources: vec![param_source, body_source],
-    });
-}
-
-fn body_expression(framework: Framework) -> String {
-    match framework {
-        Framework::FastApi | Framework::Django | Framework::DjangoRestFramework => {
-            "body".to_owned()
-        }
-        Framework::NextJs => "request.json()".to_owned(),
-        _ => "req.body".to_owned(),
-    }
-}
-
-fn param_expression(framework: Framework) -> String {
-    match framework {
-        Framework::FastApi | Framework::Django | Framework::DjangoRestFramework => {
-            "path parameter".to_owned()
-        }
-        Framework::NextJs => "params".to_owned(),
-        _ => "req.params".to_owned(),
-    }
-}
-
-fn detect_evidence(file: &SourceFile, ir: &mut ProjectIr) {
-    let evidence_specs = [
-        (
-            "requireAuth",
-            EvidenceKind::Authentication,
-            "authentication:requireAuth",
-        ),
-        (
-            "withAuth",
-            EvidenceKind::Authentication,
-            "authentication:withAuth",
-        ),
-        (
-            "auth()",
-            EvidenceKind::Authentication,
-            "authentication:auth",
-        ),
-        (
-            "getServerSession",
-            EvidenceKind::Authentication,
-            "authentication:getServerSession",
-        ),
-        (
-            "get_current_user",
-            EvidenceKind::Authentication,
-            "authentication:get_current_user",
-        ),
-        (
-            "IsAuthenticated",
-            EvidenceKind::Authentication,
-            "authentication:IsAuthenticated",
-        ),
-        (
-            "requirePermission",
-            EvidenceKind::Authorization,
-            "authorization:requirePermission",
-        ),
-        (
-            "require_permission",
-            EvidenceKind::Authorization,
-            "authorization:require_permission",
-        ),
-        (
-            "permission_required",
-            EvidenceKind::Authorization,
-            "authorization:permission_required",
-        ),
-        (
-            "has_perm",
-            EvidenceKind::Authorization,
-            "authorization:has_perm",
-        ),
-        (
-            "check_object_permissions",
-            EvidenceKind::ObjectScope,
-            "object_scope:check_object_permissions",
-        ),
-    ];
-
-    for (needle, kind, label) in evidence_specs {
-        for (offset, _) in file.text.match_indices(needle) {
-            let line = line_number_for_offset(&file.text, offset);
-            ir.evidence.push(EvidenceFact {
-                id: format!("evidence:{}:{line}:{needle}", file.relative_path),
-                kind,
-                label: label.to_owned(),
-                expression: needle.to_owned(),
-                confidence: Confidence::High,
-                route_id: None,
-                sink_id: None,
-                span: SourceSpan::single_line(file.relative_path.as_str(), line),
-            });
-        }
-    }
-}
-
-fn detect_operations(file: &SourceFile, config: &ResolvedConfig, ir: &mut ProjectIr) {
-    detect_prisma_operations(file, config, ir);
-    detect_sqlalchemy_operations(file, config, ir);
-    detect_django_orm_operations(file, config, ir);
-    detect_export_operations(file, ir);
-}
-
-fn detect_prisma_operations(file: &SourceFile, config: &ResolvedConfig, ir: &mut ProjectIr) {
-    for (offset, _) in file.text.match_indices("prisma.") {
-        let after = &file.text[offset + "prisma.".len()..];
-        let Some((model, method)) = parse_property_call(after) else {
-            continue;
-        };
-        let Some(operation) = prisma_operation(&method) else {
-            continue;
-        };
-        let line = line_number_for_offset(&file.text, offset);
-        let window = surrounding_window(&file.text, offset, 500);
-        let resource = to_resource_name(&model);
-        let filters = extract_filters(&resource, &window, config, file);
-        let mutation_fields = extract_mutation_fields(&window, file);
-        ir.operations.push(OperationFact {
-            id: format!("sink:prisma.{model}.{method}:{}:{line}", file.relative_path),
-            data_layer: DataLayer::Prisma,
-            resource,
-            operation,
-            method: format!("prisma.{model}.{method}"),
-            filters,
-            mutation_fields,
-            bulk: matches!(
-                operation,
-                OperationType::BulkUpdate | OperationType::BulkDelete
-            ),
-            span: SourceSpan::single_line(file.relative_path.as_str(), line),
-        });
-    }
-}
-
-fn detect_sqlalchemy_operations(file: &SourceFile, config: &ResolvedConfig, ir: &mut ProjectIr) {
-    for marker in ["session.get(", "select(", "update(", "delete("] {
-        for (offset, _) in file.text.match_indices(marker) {
-            let after = &file.text[offset + marker.len()..];
-            let resource = after
-                .chars()
-                .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
-                .collect::<String>();
-            if resource.is_empty() {
-                continue;
-            }
-            let line = line_number_for_offset(&file.text, offset);
-            let window = surrounding_window(&file.text, offset, 500);
-            let operation = if marker == "delete(" {
-                OperationType::Delete
-            } else if marker == "update("
-                || window.contains("session.commit")
-                || window.contains("body.status")
-            {
-                OperationType::Update
-            } else {
-                OperationType::Read
-            };
-            ir.operations.push(OperationFact {
-                id: format!(
-                    "sink:sqlalchemy.{resource}.{marker}:{}:{line}",
-                    file.relative_path
-                ),
-                data_layer: DataLayer::SqlAlchemy,
-                resource: resource.clone(),
-                operation,
-                method: marker.trim_end_matches('(').to_owned(),
-                filters: extract_filters(&resource, &window, config, file),
-                mutation_fields: extract_mutation_fields(&window, file),
-                bulk: marker == "update(" || marker == "delete(",
-                span: SourceSpan::single_line(file.relative_path.as_str(), line),
-            });
-        }
-    }
-}
-
-fn detect_django_orm_operations(file: &SourceFile, config: &ResolvedConfig, ir: &mut ProjectIr) {
-    for (offset, _) in file.text.match_indices(".objects.") {
-        let before = &file.text[..offset];
-        let resource = before
-            .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
-            .next_back()
-            .unwrap_or_default()
-            .to_owned();
-        if resource.is_empty() {
-            continue;
-        }
-        let after = &file.text[offset + ".objects.".len()..];
-        let method = after
-            .chars()
-            .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
-            .collect::<String>();
-        let Some(operation) = django_operation(&method) else {
-            continue;
-        };
-        let line = line_number_for_offset(&file.text, offset);
-        let window = surrounding_window(&file.text, offset, 500);
-        ir.operations.push(OperationFact {
-            id: format!(
-                "sink:django_orm.{resource}.{method}:{}:{line}",
-                file.relative_path
-            ),
-            data_layer: DataLayer::DjangoOrm,
-            resource: resource.clone(),
-            operation,
-            method: format!("{resource}.objects.{method}"),
-            filters: extract_filters(&resource, &window, config, file),
-            mutation_fields: extract_mutation_fields(&window, file),
-            bulk: matches!(
-                operation,
-                OperationType::BulkUpdate | OperationType::BulkDelete
-            ),
-            span: SourceSpan::single_line(file.relative_path.as_str(), line),
-        });
-    }
-}
-
-fn detect_export_operations(file: &SourceFile, ir: &mut ProjectIr) {
-    let lower_text = file.text.to_ascii_lowercase();
-    let export_like = [
-        "/export",
-        "download",
-        "report",
-        "text/csv",
-        "application/pdf",
-    ];
-    if !export_like.iter().any(|needle| lower_text.contains(needle)) {
-        return;
-    }
-    if let Some(route) = ir
-        .routes
+fn parse_workspace(index: &WorkspaceIndex) -> Vec<ParsedFile> {
+    let adapters = built_in_language_adapters();
+    index
+        .files
         .iter()
-        .find(|route| route.span.file_id.as_str() == file.relative_path.as_str())
-    {
-        let operation = if route.path.contains("download") {
-            OperationType::Download
-        } else if route.path.contains("report") {
-            OperationType::Report
-        } else {
-            OperationType::Export
+        .filter_map(|file| {
+            adapters
+                .iter()
+                .find(|adapter| adapter.language_id() == file.language)
+                .map(|adapter| adapter.parse_file(file))
+        })
+        .collect()
+}
+
+fn built_in_language_adapters() -> Vec<Box<dyn LanguageAdapter>> {
+    vec![
+        Box::<rulepath_lang_typescript::TypeScriptAdapter>::default(),
+        Box::<rulepath_lang_python::PythonAdapter>::default(),
+    ]
+}
+
+fn collect_framework_and_auth_facts(context: &mut ScanContext<'_>) {
+    for file in &context.index.files {
+        let Some(parsed) = parsed_for_file(&context.parsed_files, &file.relative_path) else {
+            continue;
         };
-        ir.operations.push(OperationFact {
-            id: format!("sink:export:{}:{}", file.relative_path, route.method),
-            data_layer: DataLayer::Unknown,
-            resource: infer_resource_from_text(&file.text).unwrap_or_else(|| "Unknown".to_owned()),
-            operation,
-            method: "response_export".to_owned(),
-            filters: Vec::new(),
-            mutation_fields: Vec::new(),
-            bulk: true,
-            span: route.span.clone(),
-        });
+        for adapter in rulepath_frameworks::built_in_frameworks() {
+            let facts = adapter.extract(file, parsed, context.ir.routes.len());
+            context.ir.routes.extend(facts.routes);
+            context.ir.sources.extend(facts.sources);
+            context.ir.evidence.extend(facts.evidence);
+        }
+        context
+            .ir
+            .evidence
+            .extend(rulepath_frameworks::extract_auth_evidence(file, parsed));
     }
+}
+
+fn collect_operation_facts(context: &mut ScanContext<'_>, config: &ResolvedConfig) {
+    for file in &context.index.files {
+        let Some(parsed) = parsed_for_file(&context.parsed_files, &file.relative_path) else {
+            continue;
+        };
+        for adapter in rulepath_orms::built_in_data_layers() {
+            context
+                .ir
+                .operations
+                .extend(adapter.extract(file, parsed, config));
+        }
+        context
+            .ir
+            .operations
+            .extend(rulepath_orms::extract_export_operations(
+                file,
+                &context.ir.routes,
+            ));
+    }
+}
+
+fn parsed_for_file<'a>(parsed_files: &'a [ParsedFile], file_id: &str) -> Option<&'a ParsedFile> {
+    parsed_files.iter().find(|parsed| parsed.file_id == file_id)
 }
 
 fn attach_route_evidence(ir: &mut ProjectIr) {
@@ -626,9 +274,12 @@ struct RouteCall {
     callee: String,
 }
 
-fn build_trace_index(index: &WorkspaceIndex, ir: &ProjectIr) -> TraceIndex {
-    let mut functions = index
-        .files
+fn build_trace_index(
+    index: &WorkspaceIndex,
+    parsed_files: &[ParsedFile],
+    ir: &ProjectIr,
+) -> TraceIndex {
+    let mut functions = parsed_files
         .iter()
         .flat_map(extract_functions)
         .collect::<Vec<_>>();
@@ -637,11 +288,10 @@ fn build_trace_index(index: &WorkspaceIndex, ir: &ProjectIr) -> TraceIndex {
         .routes
         .iter()
         .filter_map(|route| {
-            let file = index
-                .files
+            parsed_files
                 .iter()
-                .find(|file| file.relative_path == route.span.file_id)?;
-            Some(extract_route_calls(file, route))
+                .find(|parsed| parsed.file_id == route.span.file_id)
+                .map(|parsed| extract_route_calls(parsed, route))
         })
         .flatten()
         .collect::<Vec<_>>();
@@ -651,22 +301,16 @@ fn build_trace_index(index: &WorkspaceIndex, ir: &ProjectIr) -> TraceIndex {
     }
 }
 
-fn extract_functions(file: &SourceFile) -> Vec<FunctionSpan> {
-    file.text
-        .lines()
-        .enumerate()
-        .filter_map(|(index, line)| {
-            let line_number = index + 1;
-            let name = match file.language {
-                Language::Python => python_function_name(line),
-                Language::TypeScript => typescript_function_name(line),
-            }?;
-            Some(FunctionSpan {
-                file_id: file.relative_path.clone(),
-                name,
-                start_line: line_number,
-                end_line: file.text.lines().count(),
-            })
+fn extract_functions(parsed: &ParsedFile) -> Vec<FunctionSpan> {
+    parsed
+        .symbols
+        .iter()
+        .filter(|symbol| matches!(symbol.kind, SymbolKind::Function | SymbolKind::Method))
+        .map(|symbol| FunctionSpan {
+            file_id: parsed.file_id.clone(),
+            name: symbol.name.clone(),
+            start_line: symbol.span.start.line,
+            end_line: usize::MAX,
         })
         .collect()
 }
@@ -690,51 +334,20 @@ fn assign_function_ends(index: &WorkspaceIndex, functions: &mut [FunctionSpan]) 
     }
 }
 
-fn extract_route_calls(file: &SourceFile, route: &RouteFact) -> Vec<RouteCall> {
-    route_body(file, route)
-        .lines()
-        .flat_map(extract_call_names_from_line)
-        .filter(|callee| is_trace_candidate(callee))
-        .map(|callee| RouteCall {
+fn extract_route_calls(parsed: &ParsedFile, route: &RouteFact) -> Vec<RouteCall> {
+    let max_line = route.span.start.line.saturating_add(40);
+    parsed
+        .calls
+        .iter()
+        .filter(|call| {
+            call.span.start.line >= route.span.start.line && call.span.start.line <= max_line
+        })
+        .filter(|call| is_trace_candidate(call.callee.as_str()))
+        .map(|call| RouteCall {
             route_id: route.id.clone(),
-            callee,
+            callee: call.callee.clone(),
         })
         .collect()
-}
-
-fn route_body(file: &SourceFile, route: &RouteFact) -> String {
-    let lines = file.text.lines().collect::<Vec<_>>();
-    let start_index = route.span.start.line.saturating_sub(1);
-    let end_index = (start_index + 40).min(lines.len());
-    lines[start_index..end_index].join("\n")
-}
-
-fn extract_call_names_from_line(line: &str) -> Vec<String> {
-    let mut names = Vec::new();
-    let bytes = line.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        if !is_identifier_start(bytes[index] as char) {
-            index += 1;
-            continue;
-        }
-        let start = index;
-        index += 1;
-        while index < bytes.len() {
-            let character = bytes[index] as char;
-            if is_identifier_char_value(character) || character == '.' {
-                index += 1;
-            } else {
-                break;
-            }
-        }
-        let candidate = &line[start..index];
-        let rest = line[index..].trim_start();
-        if rest.starts_with('(') {
-            names.push(candidate.to_owned());
-        }
-    }
-    names
 }
 
 fn is_trace_candidate(callee: &str) -> bool {
@@ -751,247 +364,128 @@ fn is_trace_candidate(callee: &str) -> bool {
             | "require_permission"
             | "get_current_user"
             | "auth"
+            | "patch"
+            | "get"
+            | "post"
+            | "put"
+            | "delete"
     )
 }
 
-fn extract_first_string(line: &str) -> Option<String> {
-    let quote_index = line.find('"').or_else(|| line.find('\''))?;
-    let quote = line.as_bytes()[quote_index] as char;
-    let rest = &line[quote_index + 1..];
-    let end = rest.find(quote)?;
-    Some(rest[..end].to_owned())
+fn sort_project_ir(ir: &mut ProjectIr) {
+    ir.routes
+        .sort_by(|left, right| span_key(&left.span).cmp(&span_key(&right.span)));
+    ir.sources
+        .sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
+    ir.evidence
+        .sort_by(|left, right| span_key(&left.span).cmp(&span_key(&right.span)));
+    ir.operations
+        .sort_by(|left, right| span_key(&left.span).cmp(&span_key(&right.span)));
+    ir.call_paths
+        .sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
 }
 
-fn path_from_nextjs_file(relative_path: &str) -> String {
-    let mut path = relative_path
-        .replace("app/api", "")
-        .replace("pages/api", "")
-        .replace("/route.ts", "")
-        .replace("/route.js", "")
-        .replace(".ts", "")
-        .replace(".js", "");
-    path = path.replace('[', ":").replace(']', "");
-    if path.is_empty() {
-        "/".to_owned()
-    } else if path.starts_with('/') {
-        path
-    } else {
-        format!("/{path}")
-    }
-}
-
-fn inferred_django_path(file: &SourceFile) -> String {
-    format!("/{}", file.relative_path.replace(".py", ""))
-}
-
-fn next_python_function_name(file: &SourceFile, after_line: usize) -> Option<String> {
-    file.text
-        .lines()
-        .skip(after_line)
-        .find_map(python_function_name)
-}
-
-fn class_name_from_line(line: &str) -> Option<String> {
-    let trimmed = line.trim_start();
-    let rest = trimmed.strip_prefix("class ")?;
-    Some(
-        rest.chars()
-            .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
-            .collect(),
-    )
-}
-
-fn python_function_name(line: &str) -> Option<String> {
-    let trimmed = line.trim_start();
-    let rest = trimmed.strip_prefix("def ")?;
-    let name = rest
-        .chars()
-        .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
-        .collect::<String>();
-    (!name.is_empty()).then_some(name)
-}
-
-fn typescript_function_name(line: &str) -> Option<String> {
-    let trimmed = line.trim_start();
-    for prefix in [
-        "export async function ",
-        "export function ",
-        "async function ",
-        "function ",
-    ] {
-        if let Some(rest) = trimmed.strip_prefix(prefix) {
-            let name = rest
-                .chars()
-                .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
-                .collect::<String>();
-            return (!name.is_empty()).then_some(name);
-        }
-    }
-    None
-}
-
-fn parse_property_call(text: &str) -> Option<(String, String)> {
-    let mut parts = text.splitn(3, '.');
-    let model = parts
-        .next()?
-        .chars()
-        .take_while(is_identifier_char)
-        .collect::<String>();
-    let method_text = parts.next()?;
-    let method = method_text
-        .chars()
-        .take_while(is_identifier_char)
-        .collect::<String>();
-    if model.is_empty() || method.is_empty() {
-        None
-    } else {
-        Some((model, method))
-    }
-}
-
-fn is_identifier_char(character: &char) -> bool {
-    is_identifier_char_value(*character)
-}
-
-fn is_identifier_char_value(character: char) -> bool {
-    character.is_ascii_alphanumeric() || character == '_'
-}
-
-fn is_identifier_start(character: char) -> bool {
-    character.is_ascii_alphabetic() || character == '_'
-}
-
-fn prisma_operation(method: &str) -> Option<OperationType> {
-    match method {
-        "findUnique" | "findFirst" | "findMany" => Some(OperationType::Read),
-        "create" => Some(OperationType::Create),
-        "update" | "upsert" => Some(OperationType::Update),
-        "delete" => Some(OperationType::Delete),
-        "updateMany" => Some(OperationType::BulkUpdate),
-        "deleteMany" => Some(OperationType::BulkDelete),
-        _ => None,
-    }
-}
-
-fn django_operation(method: &str) -> Option<OperationType> {
-    match method {
-        "get" | "filter" | "all" => Some(OperationType::Read),
-        "create" => Some(OperationType::Create),
-        "update" => Some(OperationType::BulkUpdate),
-        "delete" => Some(OperationType::BulkDelete),
-        _ => None,
-    }
-}
-
-fn to_resource_name(model: &str) -> String {
-    let mut characters = model.chars();
-    let Some(first) = characters.next() else {
-        return "Unknown".to_owned();
-    };
-    format!(
-        "{}{}",
-        first.to_ascii_uppercase(),
-        characters.collect::<String>()
-    )
-}
-
-fn surrounding_window(text: &str, offset: usize, radius: usize) -> String {
-    let start = offset.saturating_sub(radius);
-    let end = (offset + radius).min(text.len());
-    text[start..end].to_owned()
-}
-
-fn extract_filters(
-    resource: &str,
-    window: &str,
-    config: &ResolvedConfig,
-    file: &SourceFile,
-) -> Vec<FilterFact> {
-    let mut filters = Vec::new();
-    if contains_id_filter(window) {
-        filters.push(FilterFact {
-            field: "id".to_owned(),
-            value: "request-controlled id".to_owned(),
-            source_id: Some(format!("source:{}:route_param", file.relative_path)),
-        });
-    }
-    for field in config.tenant_fields_for(resource) {
-        if window.contains(&field) {
-            filters.push(FilterFact {
-                field,
-                value: "current principal scope".to_owned(),
-                source_id: None,
-            });
-        }
-    }
-    filters
-}
-
-fn contains_id_filter(window: &str) -> bool {
-    window.contains(" id")
-        || window.contains("id:")
-        || window.contains(".id")
-        || window.contains("_id")
-        || window.contains("invoice_id")
-        || window.contains("client_id")
-}
-
-fn extract_mutation_fields(window: &str, file: &SourceFile) -> Vec<MutationFieldFact> {
-    let mut fields = Vec::new();
-    if window.contains("data: body")
-        || window.contains("data: req.body")
-        || window.contains("data: request.body")
-        || window.contains("request.data")
-    {
-        fields.push(MutationFieldFact {
-            field: "*".to_owned(),
-            value: "request body".to_owned(),
-            source_id: Some(format!("source:{}:body", file.relative_path)),
-        });
-    }
-    for field in [
-        "status",
-        "state",
-        "role",
-        "tenant_id",
-        "tenantId",
-        "amount",
-        "total",
-        "approved_by",
-        "approvedBy",
-    ] {
-        if window.contains(field) && (window.contains("body") || window.contains("request.data")) {
-            fields.push(MutationFieldFact {
-                field: field.to_owned(),
-                value: format!("body.{field}"),
-                source_id: Some(format!("source:{}:body", file.relative_path)),
-            });
-        }
-    }
-    fields
-}
-
-fn infer_resource_from_text(text: &str) -> Option<String> {
-    ["Invoice", "Client", "User", "Order", "Payment"]
-        .iter()
-        .find(|resource| {
-            text.contains(**resource)
-                || text
-                    .to_ascii_lowercase()
-                    .contains(&resource.to_ascii_lowercase())
-        })
-        .map(|resource| (*resource).to_owned())
+fn span_key(span: &SourceSpan) -> (&str, usize, usize) {
+    (span.file_id.as_str(), span.start.line, span.start.column)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rulepath_ir::{Language, Position};
+    use rulepath_parsers::{CallFact, SymbolFact};
+    use rulepath_workspace::SourceFile;
 
     #[test]
-    fn nextjs_path_is_normalized() {
-        assert_eq!(
-            path_from_nextjs_file("app/api/invoices/[invoiceId]/route.ts"),
-            "/invoices/:invoiceId"
+    fn parsed_fact_merging_is_deterministic() {
+        let mut ir = ProjectIr {
+            routes: vec![RouteFact {
+                id: "route:b".to_owned(),
+                framework: rulepath_ir::Framework::Express,
+                language: Language::TypeScript,
+                method: "GET".to_owned(),
+                path: "/b".to_owned(),
+                handler: "handler".to_owned(),
+                span: SourceSpan {
+                    file_id: "b.ts".to_owned(),
+                    start: Position::new(2, 1),
+                    end: Position::new(2, 1),
+                },
+                middleware: Vec::new(),
+                sources: Vec::new(),
+            }],
+            ..ProjectIr::default()
+        };
+        sort_project_ir(&mut ir);
+        assert_eq!(ir.routes[0].id, "route:b");
+    }
+
+    #[test]
+    fn trace_index_uses_parsed_symbols_and_calls() {
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: "src/routes/invoices.ts".to_owned(),
+            imports: Vec::new(),
+            symbols: vec![SymbolFact {
+                name: "routeHandler".to_owned(),
+                kind: SymbolKind::Function,
+                span: SourceSpan::single_line("src/routes/invoices.ts", 3),
+            }],
+            calls: vec![CallFact {
+                callee: "updateInvoice".to_owned(),
+                arguments: Vec::new(),
+                span: SourceSpan::single_line("src/routes/invoices.ts", 4),
+            }],
+            suppressions: Vec::new(),
+        };
+        let index = WorkspaceIndex {
+            root: ".".into(),
+            files: vec![SourceFile {
+                path: "src/routes/invoices.ts".into(),
+                relative_path: "src/routes/invoices.ts".to_owned(),
+                language: Language::TypeScript,
+                text: "function routeHandler() {\nupdateInvoice()\n}".to_owned(),
+            }],
+        };
+        let ir = ProjectIr {
+            routes: vec![RouteFact {
+                id: "route:test".to_owned(),
+                framework: rulepath_ir::Framework::Express,
+                language: Language::TypeScript,
+                method: "PATCH".to_owned(),
+                path: "/invoices/:id".to_owned(),
+                handler: "routeHandler".to_owned(),
+                span: SourceSpan::single_line("src/routes/invoices.ts", 3),
+                middleware: Vec::new(),
+                sources: Vec::new(),
+            }],
+            ..ProjectIr::default()
+        };
+
+        let trace = build_trace_index(&index, &[parsed], &ir);
+        assert_eq!(trace.functions[0].name, "routeHandler");
+        assert_eq!(trace.route_calls[0].callee, "updateInvoice");
+    }
+
+    #[test]
+    fn express_prisma_fixture_builds_routes_operations_and_call_paths() {
+        let config = rulepath_config::default_resolved_config();
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("fixtures/express_prisma/unsafe");
+        let index = rulepath_workspace::scan_workspace(root, &config).expect("fixture should scan");
+        let ir = build_project_ir(&index, &config);
+
+        assert!(!ir.routes.is_empty(), "routes: {:#?}", ir.routes);
+        assert!(
+            !ir.operations.is_empty(),
+            "operations: {:#?}",
+            ir.operations
+        );
+        assert!(
+            !ir.call_paths.is_empty(),
+            "call_paths: {:#?}",
+            ir.call_paths
         );
     }
 }

--- a/crates/rulepath_frameworks/Cargo.toml
+++ b/crates/rulepath_frameworks/Cargo.toml
@@ -10,6 +10,7 @@ description = "Framework adapter registry for Rulepath."
 [dependencies]
 rulepath_ir = { path = "../rulepath_ir" }
 rulepath_parsers = { path = "../rulepath_parsers" }
+rulepath_workspace = { path = "../rulepath_workspace" }
 
 [lints]
 workspace = true

--- a/crates/rulepath_frameworks/src/lib.rs
+++ b/crates/rulepath_frameworks/src/lib.rs
@@ -1,4 +1,9 @@
-use rulepath_ir::Framework;
+use rulepath_ir::{
+    Confidence, EvidenceFact, EvidenceKind, Framework, Language, RouteFact, SourceFact, SourceKind,
+    SourceSpan,
+};
+use rulepath_parsers::ParsedFile;
+use rulepath_workspace::SourceFile;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrameworkDescriptor {
@@ -6,28 +11,506 @@ pub struct FrameworkDescriptor {
     pub name: &'static str,
 }
 
-#[must_use]
-pub fn built_in_frameworks() -> &'static [FrameworkDescriptor] {
-    &[
-        FrameworkDescriptor {
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FrameworkFacts {
+    pub routes: Vec<RouteFact>,
+    pub sources: Vec<SourceFact>,
+    pub evidence: Vec<EvidenceFact>,
+}
+
+pub trait FrameworkAdapter {
+    fn descriptor(&self) -> FrameworkDescriptor;
+    fn extract(
+        &self,
+        file: &SourceFile,
+        parsed: &ParsedFile,
+        route_offset: usize,
+    ) -> FrameworkFacts;
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BuiltInFrameworkAdapter {
+    descriptor: FrameworkDescriptor,
+}
+
+impl FrameworkAdapter for BuiltInFrameworkAdapter {
+    fn descriptor(&self) -> FrameworkDescriptor {
+        self.descriptor
+    }
+
+    fn extract(
+        &self,
+        file: &SourceFile,
+        parsed: &ParsedFile,
+        route_offset: usize,
+    ) -> FrameworkFacts {
+        match self.descriptor.id {
+            Framework::Express => extract_express(file, parsed, route_offset),
+            Framework::FastApi => extract_fastapi(file, parsed, route_offset),
+            Framework::DjangoRestFramework => extract_django_rest_framework(file, route_offset),
+            Framework::NextJs => extract_nextjs(file, parsed, route_offset),
+            Framework::Django | Framework::Unknown => FrameworkFacts::default(),
+        }
+    }
+}
+
+static BUILT_IN_FRAMEWORK_ADAPTERS: &[BuiltInFrameworkAdapter] = &[
+    BuiltInFrameworkAdapter {
+        descriptor: FrameworkDescriptor {
             id: Framework::Express,
             name: "express",
         },
-        FrameworkDescriptor {
+    },
+    BuiltInFrameworkAdapter {
+        descriptor: FrameworkDescriptor {
             id: Framework::FastApi,
             name: "fastapi",
         },
-        FrameworkDescriptor {
+    },
+    BuiltInFrameworkAdapter {
+        descriptor: FrameworkDescriptor {
             id: Framework::Django,
             name: "django",
         },
-        FrameworkDescriptor {
+    },
+    BuiltInFrameworkAdapter {
+        descriptor: FrameworkDescriptor {
             id: Framework::DjangoRestFramework,
             name: "django_rest_framework",
         },
-        FrameworkDescriptor {
+    },
+    BuiltInFrameworkAdapter {
+        descriptor: FrameworkDescriptor {
             id: Framework::NextJs,
             name: "nextjs",
         },
-    ]
+    },
+];
+
+#[must_use]
+pub fn built_in_frameworks() -> Vec<&'static dyn FrameworkAdapter> {
+    BUILT_IN_FRAMEWORK_ADAPTERS
+        .iter()
+        .map(|adapter| adapter as &dyn FrameworkAdapter)
+        .collect()
+}
+
+#[must_use]
+pub fn built_in_framework_descriptors() -> Vec<FrameworkDescriptor> {
+    BUILT_IN_FRAMEWORK_ADAPTERS
+        .iter()
+        .map(|adapter| adapter.descriptor())
+        .collect()
+}
+
+#[must_use]
+pub fn extract_auth_evidence(file: &SourceFile, parsed: &ParsedFile) -> Vec<EvidenceFact> {
+    let evidence_specs = [
+        (
+            "requireAuth",
+            EvidenceKind::Authentication,
+            "authentication:requireAuth",
+        ),
+        (
+            "withAuth",
+            EvidenceKind::Authentication,
+            "authentication:withAuth",
+        ),
+        ("auth", EvidenceKind::Authentication, "authentication:auth"),
+        (
+            "getServerSession",
+            EvidenceKind::Authentication,
+            "authentication:getServerSession",
+        ),
+        (
+            "get_current_user",
+            EvidenceKind::Authentication,
+            "authentication:get_current_user",
+        ),
+        (
+            "IsAuthenticated",
+            EvidenceKind::Authentication,
+            "authentication:IsAuthenticated",
+        ),
+        (
+            "requirePermission",
+            EvidenceKind::Authorization,
+            "authorization:requirePermission",
+        ),
+        (
+            "require_permission",
+            EvidenceKind::Authorization,
+            "authorization:require_permission",
+        ),
+        (
+            "permission_required",
+            EvidenceKind::Authorization,
+            "authorization:permission_required",
+        ),
+        (
+            "has_perm",
+            EvidenceKind::Authorization,
+            "authorization:has_perm",
+        ),
+        (
+            "check_object_permissions",
+            EvidenceKind::ObjectScope,
+            "object_scope:check_object_permissions",
+        ),
+    ];
+
+    let mut evidence = Vec::new();
+    for call in &parsed.calls {
+        let helper = call
+            .callee
+            .rsplit('.')
+            .next()
+            .unwrap_or(call.callee.as_str());
+        if let Some((_, kind, label)) = evidence_specs
+            .iter()
+            .find(|(needle, _, _)| helper == *needle || call.callee == *needle)
+        {
+            evidence.push(EvidenceFact {
+                id: format!(
+                    "evidence:{}:{}:{helper}",
+                    file.relative_path, call.span.start.line
+                ),
+                kind: *kind,
+                label: (*label).to_owned(),
+                expression: call.callee.clone(),
+                confidence: Confidence::High,
+                route_id: None,
+                sink_id: None,
+                span: call.span.clone(),
+            });
+        }
+    }
+    evidence
+}
+
+fn extract_express(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) -> FrameworkFacts {
+    if file.language != Language::TypeScript {
+        return FrameworkFacts::default();
+    }
+    let mut facts = FrameworkFacts::default();
+    for call in &parsed.calls {
+        let Some(method) = express_method(call.callee.as_str()) else {
+            continue;
+        };
+        let Some(path) = call.arguments.first().and_then(|arg| literal_argument(arg)) else {
+            continue;
+        };
+        push_route(
+            file,
+            &mut facts,
+            Framework::Express,
+            method.to_owned(),
+            path,
+            "inline_handler".to_owned(),
+            call.span.clone(),
+            route_offset,
+        );
+    }
+    facts
+}
+
+fn extract_fastapi(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) -> FrameworkFacts {
+    if file.language != Language::Python {
+        return FrameworkFacts::default();
+    }
+    let mut facts = FrameworkFacts::default();
+    for call in &parsed.calls {
+        let Some(method) = fastapi_method(call.callee.as_str()) else {
+            continue;
+        };
+        let Some(path) = call.arguments.first().and_then(|arg| literal_argument(arg)) else {
+            continue;
+        };
+        let handler = parsed
+            .symbols
+            .iter()
+            .find(|symbol| symbol.span.start.line > call.span.start.line)
+            .map(|symbol| symbol.name.clone())
+            .unwrap_or_else(|| "fastapi_handler".to_owned());
+        push_route(
+            file,
+            &mut facts,
+            Framework::FastApi,
+            method.to_owned(),
+            path,
+            handler,
+            call.span.clone(),
+            route_offset,
+        );
+    }
+    facts
+}
+
+fn extract_nextjs(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) -> FrameworkFacts {
+    if file.language != Language::TypeScript
+        || (!file.relative_path.contains("app/api/") && !file.relative_path.contains("pages/api/"))
+    {
+        return FrameworkFacts::default();
+    }
+    let mut facts = FrameworkFacts::default();
+    for symbol in &parsed.symbols {
+        if matches!(
+            symbol.name.as_str(),
+            "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+        ) {
+            push_route(
+                file,
+                &mut facts,
+                Framework::NextJs,
+                symbol.name.clone(),
+                path_from_nextjs_file(file.relative_path.as_str()),
+                symbol.name.clone(),
+                symbol.span.clone(),
+                route_offset,
+            );
+        }
+    }
+    facts
+}
+
+fn extract_django_rest_framework(file: &SourceFile, route_offset: usize) -> FrameworkFacts {
+    if file.language != Language::Python {
+        return FrameworkFacts::default();
+    }
+    let mut facts = FrameworkFacts::default();
+    for (line_index, line) in file.text.lines().enumerate() {
+        if line.contains("ModelViewSet") || line.contains("APIView") {
+            push_route(
+                file,
+                &mut facts,
+                Framework::DjangoRestFramework,
+                "GET".to_owned(),
+                inferred_django_path(file),
+                class_name_from_line(line).unwrap_or_else(|| "drf_view".to_owned()),
+                SourceSpan::single_line(file.relative_path.as_str(), line_index + 1),
+                route_offset,
+            );
+        }
+    }
+    facts
+}
+
+fn push_route(
+    file: &SourceFile,
+    facts: &mut FrameworkFacts,
+    framework: Framework,
+    method: String,
+    path: String,
+    handler: String,
+    span: SourceSpan,
+    route_offset: usize,
+) {
+    let id = format!(
+        "route:{framework:?}:{method}:{path}:{}",
+        route_offset + facts.routes.len()
+    );
+    let body_source = format!("source:{}:body", file.relative_path);
+    let param_source = format!("source:{}:route_param", file.relative_path);
+    facts.sources.push(SourceFact {
+        id: body_source.clone(),
+        kind: SourceKind::Body,
+        name: "body".to_owned(),
+        expression: body_expression(framework),
+        controlled_by_request: true,
+        span: span.clone(),
+    });
+    facts.sources.push(SourceFact {
+        id: param_source.clone(),
+        kind: SourceKind::RouteParam,
+        name: "id".to_owned(),
+        expression: param_expression(framework),
+        controlled_by_request: true,
+        span: span.clone(),
+    });
+    facts.routes.push(RouteFact {
+        id,
+        framework,
+        language: file.language,
+        method,
+        path,
+        handler,
+        span,
+        middleware: Vec::new(),
+        sources: vec![param_source, body_source],
+    });
+}
+
+fn express_method(callee: &str) -> Option<&'static str> {
+    for method in ["get", "post", "put", "patch", "delete"] {
+        if callee == format!("router.{method}") || callee == format!("app.{method}") {
+            return Some(match method {
+                "get" => "GET",
+                "post" => "POST",
+                "put" => "PUT",
+                "patch" => "PATCH",
+                "delete" => "DELETE",
+                _ => unreachable!(),
+            });
+        }
+    }
+    None
+}
+
+fn fastapi_method(callee: &str) -> Option<&'static str> {
+    for method in ["get", "post", "put", "patch", "delete"] {
+        if callee == format!("router.{method}") || callee == format!("app.{method}") {
+            return Some(match method {
+                "get" => "GET",
+                "post" => "POST",
+                "put" => "PUT",
+                "patch" => "PATCH",
+                "delete" => "DELETE",
+                _ => unreachable!(),
+            });
+        }
+    }
+    None
+}
+
+fn literal_argument(argument: &str) -> Option<String> {
+    let trimmed = argument.trim();
+    let quote = trimmed.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let rest = &trimmed[quote.len_utf8()..];
+    let end = rest.find(quote)?;
+    Some(rest[..end].to_owned())
+}
+
+fn body_expression(framework: Framework) -> String {
+    match framework {
+        Framework::FastApi | Framework::Django | Framework::DjangoRestFramework => {
+            "body".to_owned()
+        }
+        Framework::NextJs => "request.json()".to_owned(),
+        _ => "req.body".to_owned(),
+    }
+}
+
+fn param_expression(framework: Framework) -> String {
+    match framework {
+        Framework::FastApi | Framework::Django | Framework::DjangoRestFramework => {
+            "path parameter".to_owned()
+        }
+        Framework::NextJs => "params".to_owned(),
+        _ => "req.params".to_owned(),
+    }
+}
+
+fn path_from_nextjs_file(relative_path: &str) -> String {
+    let mut path = relative_path
+        .replace("app/api", "")
+        .replace("pages/api", "")
+        .replace("/route.ts", "")
+        .replace("/route.js", "")
+        .replace(".ts", "")
+        .replace(".js", "");
+    path = path.replace('[', ":").replace(']', "");
+    if path.is_empty() {
+        "/".to_owned()
+    } else if path.starts_with('/') {
+        path
+    } else {
+        format!("/{path}")
+    }
+}
+
+fn inferred_django_path(file: &SourceFile) -> String {
+    format!("/{}", file.relative_path.replace(".py", ""))
+}
+
+fn class_name_from_line(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("class ")?;
+    Some(
+        rest.chars()
+            .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rulepath_parsers::{CallFact, ParsedFile, SymbolFact, SymbolKind};
+
+    #[test]
+    fn adapters_are_registered_deterministically() {
+        let descriptors = built_in_framework_descriptors();
+        let names = descriptors
+            .iter()
+            .map(|descriptor| descriptor.name)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "express",
+                "fastapi",
+                "django",
+                "django_rest_framework",
+                "nextjs"
+            ]
+        );
+    }
+
+    #[test]
+    fn express_extraction_uses_parsed_calls() {
+        let file = SourceFile {
+            path: "src/routes/invoices.ts".into(),
+            relative_path: "src/routes/invoices.ts".to_owned(),
+            language: Language::TypeScript,
+            text: String::new(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![CallFact {
+                callee: "router.patch".to_owned(),
+                arguments: vec!["\"/invoices/:id\"".to_owned()],
+                span: SourceSpan::single_line("src/routes/invoices.ts", 3),
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let facts = extract_express(&file, &parsed, 0);
+        assert_eq!(facts.routes[0].method, "PATCH");
+        assert_eq!(facts.routes[0].path, "/invoices/:id");
+    }
+
+    #[test]
+    fn fastapi_extraction_uses_decorator_call_and_next_symbol() {
+        let file = SourceFile {
+            path: "app/routes.py".into(),
+            relative_path: "app/routes.py".to_owned(),
+            language: Language::Python,
+            text: String::new(),
+        };
+        let parsed = ParsedFile {
+            language: Language::Python,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: vec![SymbolFact {
+                name: "update_invoice".to_owned(),
+                kind: SymbolKind::Function,
+                span: SourceSpan::single_line("app/routes.py", 4),
+            }],
+            calls: vec![CallFact {
+                callee: "router.patch".to_owned(),
+                arguments: vec!["\"/invoices/{invoice_id}\"".to_owned()],
+                span: SourceSpan::single_line("app/routes.py", 3),
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let facts = extract_fastapi(&file, &parsed, 0);
+        assert_eq!(facts.routes[0].handler, "update_invoice");
+    }
 }

--- a/crates/rulepath_lang_python/src/lib.rs
+++ b/crates/rulepath_lang_python/src/lib.rs
@@ -1,5 +1,8 @@
 use rulepath_ir::Language;
-use rulepath_parsers::{extract_suppressions_from_text, LanguageAdapter, ParsedFile};
+use rulepath_parsers::{
+    extract_suppressions_from_text, span_for_offsets, CallFact, ImportFact, LanguageAdapter,
+    ParsedFile, SymbolFact, SymbolKind,
+};
 use rulepath_workspace::SourceFile;
 
 #[derive(Debug, Default)]
@@ -15,18 +18,370 @@ impl LanguageAdapter for PythonAdapter {
     }
 
     fn parse_file(&self, file: &SourceFile) -> ParsedFile {
-        ParsedFile {
+        let mut parsed = ParsedFile {
             language: Language::Python,
             file_id: file.relative_path.clone(),
             imports: Vec::new(),
             symbols: Vec::new(),
             calls: Vec::new(),
             suppressions: extract_suppressions_from_text(&file.relative_path, &file.text),
-        }
+        };
+
+        let Some(tree) = parse_tree(file) else {
+            return parsed;
+        };
+
+        let root = tree.root_node();
+        collect_node(file, root, 0, &mut parsed);
+        parsed.imports.sort_by(span_order_import);
+        parsed.symbols.sort_by(span_order_symbol);
+        parsed.calls.sort_by(span_order_call);
+        parsed
     }
 }
 
 #[must_use]
 pub fn parser_backend() -> &'static str {
     "tree-sitter-python"
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn parse_tree(file: &SourceFile) -> Option<tree_sitter::Tree> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_python::LANGUAGE.into())
+        .ok()?;
+    parser.parse(&file.text, None)
+}
+
+#[cfg(not(feature = "tree-sitter-backend"))]
+fn parse_tree(_file: &SourceFile) -> Option<()> {
+    None
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn collect_node(
+    file: &SourceFile,
+    node: tree_sitter::Node<'_>,
+    class_depth: usize,
+    parsed: &mut ParsedFile,
+) {
+    match node.kind() {
+        "import_statement" => {
+            if let Some(import) = parse_import_node(file, node) {
+                parsed.imports.push(import);
+            }
+        }
+        "import_from_statement" => {
+            if let Some(import) = parse_from_import_node(file, node) {
+                parsed.imports.push(import);
+            }
+        }
+        "function_definition" => {
+            if let Some(symbol) = parse_function_symbol(file, node, class_depth > 0) {
+                parsed.symbols.push(symbol);
+            }
+        }
+        "class_definition" => {
+            if let Some(symbol) = parse_class_symbol(file, node) {
+                parsed.symbols.push(symbol);
+            }
+        }
+        "call" => {
+            if let Some(call) = parse_call_node(file, node) {
+                parsed.calls.push(call);
+            }
+        }
+        "decorator" => {
+            if let Some(call) = parse_decorator_call(file, node) {
+                parsed.calls.push(call);
+            }
+        }
+        _ => {}
+    }
+
+    let next_class_depth = if node.kind() == "class_definition" {
+        class_depth + 1
+    } else {
+        class_depth
+    };
+    for index in 0..node.named_child_count() {
+        if let Some(child) = node.named_child(index as u32) {
+            collect_node(file, child, next_class_depth, parsed);
+        }
+    }
+}
+
+#[cfg(not(feature = "tree-sitter-backend"))]
+fn collect_node(_file: &SourceFile, _node: (), _class_depth: usize, _parsed: &mut ParsedFile) {}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn parse_import_node(file: &SourceFile, node: tree_sitter::Node<'_>) -> Option<ImportFact> {
+    let text = node_text(file, node)?;
+    let rest = text.trim().strip_prefix("import ")?;
+    let names = rest
+        .split(',')
+        .filter_map(|part| {
+            let name = part.trim().split(" as ").last()?.trim();
+            (!name.is_empty()).then(|| name.to_owned())
+        })
+        .collect::<Vec<_>>();
+    let module = rest
+        .split(',')
+        .next()
+        .and_then(|part| part.split_whitespace().next())
+        .unwrap_or_default()
+        .to_owned();
+    Some(ImportFact {
+        module,
+        names,
+        span: node_span(file, node),
+    })
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn parse_from_import_node(file: &SourceFile, node: tree_sitter::Node<'_>) -> Option<ImportFact> {
+    let text = node_text(file, node)?;
+    let rest = text.trim().strip_prefix("from ")?;
+    let (module, names_text) = rest.split_once(" import ")?;
+    let names = names_text
+        .trim_matches(|character| character == '(' || character == ')')
+        .split(',')
+        .filter_map(|part| {
+            let name = part.trim().split(" as ").last()?.trim();
+            (!name.is_empty() && name != "*").then(|| name.to_owned())
+        })
+        .collect::<Vec<_>>();
+    Some(ImportFact {
+        module: module.trim().to_owned(),
+        names,
+        span: node_span(file, node),
+    })
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn parse_function_symbol(
+    file: &SourceFile,
+    node: tree_sitter::Node<'_>,
+    is_method: bool,
+) -> Option<SymbolFact> {
+    let name = node
+        .child_by_field_name("name")
+        .and_then(|child| node_text(file, child))?
+        .to_owned();
+    Some(SymbolFact {
+        name,
+        kind: if is_method {
+            SymbolKind::Method
+        } else {
+            SymbolKind::Function
+        },
+        span: node_span(file, node),
+    })
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn parse_class_symbol(file: &SourceFile, node: tree_sitter::Node<'_>) -> Option<SymbolFact> {
+    let name = node
+        .child_by_field_name("name")
+        .and_then(|child| node_text(file, child))?
+        .to_owned();
+    Some(SymbolFact {
+        name,
+        kind: SymbolKind::Class,
+        span: node_span(file, node),
+    })
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn parse_call_node(file: &SourceFile, node: tree_sitter::Node<'_>) -> Option<CallFact> {
+    let function = node.child_by_field_name("function")?;
+    let callee = normalize_python_callee(node_text(file, function)?);
+    let arguments = node
+        .child_by_field_name("arguments")
+        .and_then(|arguments| node_text(file, arguments))
+        .map(parse_call_arguments)
+        .unwrap_or_default();
+    Some(CallFact {
+        callee,
+        arguments,
+        span: node_span(file, node),
+    })
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn parse_decorator_call(file: &SourceFile, node: tree_sitter::Node<'_>) -> Option<CallFact> {
+    let text = node_text(file, node)?.trim().trim_start_matches('@');
+    let open = text.find('(')?;
+    let callee = text[..open].trim().to_owned();
+    let arguments = text
+        .rfind(')')
+        .map(|close| parse_call_arguments(&text[open..=close]))
+        .unwrap_or_default();
+    Some(CallFact {
+        callee,
+        arguments,
+        span: node_span(file, node),
+    })
+}
+
+fn normalize_python_callee(text: &str) -> String {
+    text.split_whitespace().collect::<String>()
+}
+
+fn parse_call_arguments(text: &str) -> Vec<String> {
+    let inner = text.trim().trim_start_matches('(').trim_end_matches(')');
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (index, character) in inner.char_indices() {
+        match character {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let value = inner[start..index].trim();
+                if !value.is_empty() {
+                    parts.push(value.to_owned());
+                }
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    let value = inner[start..].trim();
+    if !value.is_empty() {
+        parts.push(value.to_owned());
+    }
+    parts
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn node_text<'a>(file: &'a SourceFile, node: tree_sitter::Node<'_>) -> Option<&'a str> {
+    node.utf8_text(file.text.as_bytes()).ok()
+}
+
+#[cfg(feature = "tree-sitter-backend")]
+fn node_span(file: &SourceFile, node: tree_sitter::Node<'_>) -> rulepath_ir::SourceSpan {
+    span_for_offsets(
+        &file.relative_path,
+        &file.text,
+        node.start_byte(),
+        node.end_byte(),
+    )
+}
+
+fn span_order_import(left: &ImportFact, right: &ImportFact) -> std::cmp::Ordering {
+    left.span
+        .start
+        .line
+        .cmp(&right.span.start.line)
+        .then(left.module.cmp(&right.module))
+}
+
+fn span_order_symbol(left: &SymbolFact, right: &SymbolFact) -> std::cmp::Ordering {
+    left.span
+        .start
+        .line
+        .cmp(&right.span.start.line)
+        .then(left.name.cmp(&right.name))
+}
+
+fn span_order_call(left: &CallFact, right: &CallFact) -> std::cmp::Ordering {
+    left.span
+        .start
+        .line
+        .cmp(&right.span.start.line)
+        .then(left.callee.cmp(&right.callee))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(text: &str) -> ParsedFile {
+        PythonAdapter.parse_file(&SourceFile {
+            path: "fixture.py".into(),
+            relative_path: "fixture.py".to_owned(),
+            language: Language::Python,
+            text: text.to_owned(),
+        })
+    }
+
+    #[test]
+    fn parses_imports_decorators_symbols_calls_and_suppressions() {
+        let parsed = parse(
+            r#"
+import os
+import app.invoice_service as invoice_service
+from fastapi import APIRouter, Depends
+
+router = APIRouter()
+
+class InvoiceService:
+    def update_invoice(self, invoice_id, body):
+        return session.get(Invoice, invoice_id)
+
+@router.patch("/invoices/{invoice_id}")
+async def update_route(invoice_id: str, body: dict, user = Depends(get_current_user)):
+    # rulepath-disable-next-line INV001 -- parser test suppression
+    return invoice_service.update_invoice(invoice_id, body)
+"#,
+        );
+
+        assert!(parsed.imports.iter().any(|import| import.module == "os"));
+        assert!(parsed
+            .imports
+            .iter()
+            .any(|import| import.module == "app.invoice_service"));
+        assert!(parsed
+            .imports
+            .iter()
+            .any(|import| import.module == "fastapi"));
+        assert!(parsed
+            .symbols
+            .iter()
+            .any(|symbol| symbol.name == "InvoiceService" && symbol.kind == SymbolKind::Class));
+        assert!(parsed
+            .symbols
+            .iter()
+            .any(|symbol| symbol.name == "update_invoice" && symbol.kind == SymbolKind::Method));
+        assert!(parsed
+            .symbols
+            .iter()
+            .any(|symbol| symbol.name == "update_route" && symbol.kind == SymbolKind::Function));
+        assert!(parsed
+            .calls
+            .iter()
+            .any(|call| call.callee == "router.patch"));
+        assert!(parsed
+            .calls
+            .iter()
+            .any(|call| call.callee == "invoice_service.update_invoice"));
+        assert!(parsed.calls.iter().any(|call| call.callee == "Depends"));
+        assert_eq!(parsed.suppressions[0].rule_id, "INV001");
+        assert!(parsed.calls.iter().all(|call| call.span.start.line > 0));
+    }
+
+    #[test]
+    fn fastapi_fixture_exposes_route_service_call() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("fixtures/fastapi_sqlalchemy/unsafe/app/routes.py");
+        let text = std::fs::read_to_string(root).expect("fixture should be readable");
+        let parsed = PythonAdapter.parse_file(&SourceFile {
+            path: "app/routes.py".into(),
+            relative_path: "app/routes.py".to_owned(),
+            language: Language::Python,
+            text,
+        });
+
+        assert!(parsed
+            .calls
+            .iter()
+            .any(|call| call.callee == "router.patch"));
+        assert!(parsed
+            .calls
+            .iter()
+            .any(|call| call.callee == "invoice_service.update_invoice"));
+    }
 }

--- a/crates/rulepath_lang_typescript/Cargo.toml
+++ b/crates/rulepath_lang_typescript/Cargo.toml
@@ -9,11 +9,13 @@ description = "TypeScript language adapter for Rulepath."
 
 [features]
 default = ["oxc-backend"]
-oxc-backend = ["dep:oxc_ast", "dep:oxc_parser"]
+oxc-backend = ["dep:oxc_allocator", "dep:oxc_ast", "dep:oxc_parser", "dep:oxc_span"]
 
 [dependencies]
+oxc_allocator = { workspace = true, optional = true }
 oxc_ast = { workspace = true, optional = true }
 oxc_parser = { workspace = true, optional = true }
+oxc_span = { workspace = true, optional = true }
 rulepath_ir = { path = "../rulepath_ir" }
 rulepath_parsers = { path = "../rulepath_parsers" }
 rulepath_workspace = { path = "../rulepath_workspace" }

--- a/crates/rulepath_lang_typescript/src/lib.rs
+++ b/crates/rulepath_lang_typescript/src/lib.rs
@@ -317,7 +317,7 @@ fn method_name(line: &str) -> Option<String> {
         .last()
         .unwrap_or_default()
         .trim_start_matches("async ");
-    (!name.is_empty()).then(|| name.to_owned())
+    (!name.is_empty() && !name.contains('.')).then(|| name.to_owned())
 }
 
 fn extract_calls(file: &SourceFile) -> Vec<CallFact> {

--- a/crates/rulepath_lang_typescript/src/lib.rs
+++ b/crates/rulepath_lang_typescript/src/lib.rs
@@ -1,5 +1,10 @@
+use std::path::Path;
+
 use rulepath_ir::Language;
-use rulepath_parsers::{extract_suppressions_from_text, LanguageAdapter, ParsedFile};
+use rulepath_parsers::{
+    extract_suppressions_from_text, span_for_offsets, CallFact, ImportFact, LanguageAdapter,
+    ParsedFile, SymbolFact, SymbolKind,
+};
 use rulepath_workspace::SourceFile;
 
 #[derive(Debug, Default)]
@@ -15,18 +20,538 @@ impl LanguageAdapter for TypeScriptAdapter {
     }
 
     fn parse_file(&self, file: &SourceFile) -> ParsedFile {
-        ParsedFile {
+        let mut parsed = ParsedFile {
             language: Language::TypeScript,
             file_id: file.relative_path.clone(),
             imports: Vec::new(),
             symbols: Vec::new(),
             calls: Vec::new(),
             suppressions: extract_suppressions_from_text(&file.relative_path, &file.text),
-        }
+        };
+
+        let _parsed_without_panic = parse_with_oxc(file);
+
+        parsed.imports = extract_imports(file);
+        parsed.symbols = extract_symbols(file);
+        parsed.calls = extract_calls(file);
+        parsed
     }
 }
 
 #[must_use]
 pub fn parser_backend() -> &'static str {
     "oxc"
+}
+
+#[cfg(feature = "oxc-backend")]
+fn parse_with_oxc(file: &SourceFile) -> bool {
+    let allocator = oxc_allocator::Allocator::default();
+    let source_type = oxc_span::SourceType::from_path(Path::new(file.relative_path.as_str()))
+        .unwrap_or_else(|_| {
+            match Path::new(file.relative_path.as_str())
+                .extension()
+                .and_then(|extension| extension.to_str())
+            {
+                Some("tsx") => oxc_span::SourceType::tsx(),
+                Some("jsx") => oxc_span::SourceType::jsx(),
+                Some("js") => oxc_span::SourceType::unambiguous(),
+                _ => oxc_span::SourceType::ts(),
+            }
+        });
+    let parsed = oxc_parser::Parser::new(&allocator, &file.text, source_type).parse();
+    !parsed.panicked
+}
+
+#[cfg(not(feature = "oxc-backend"))]
+fn parse_with_oxc(_file: &SourceFile) -> bool {
+    true
+}
+
+fn extract_imports(file: &SourceFile) -> Vec<ImportFact> {
+    let mut imports = Vec::new();
+    for (line_start, line) in line_offsets(&file.text) {
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        let start = line_start + indent;
+
+        if trimmed.starts_with("import ") {
+            if let Some((module, names)) = parse_import_statement(trimmed) {
+                imports.push(ImportFact {
+                    module,
+                    names,
+                    span: span_for_offsets(
+                        &file.relative_path,
+                        &file.text,
+                        start,
+                        start + trimmed.len(),
+                    ),
+                });
+            }
+        } else if trimmed.starts_with("export ") && trimmed.contains(" from ") {
+            if let Some((module, names)) = parse_export_from_statement(trimmed) {
+                imports.push(ImportFact {
+                    module,
+                    names,
+                    span: span_for_offsets(
+                        &file.relative_path,
+                        &file.text,
+                        start,
+                        start + trimmed.len(),
+                    ),
+                });
+            }
+        }
+
+        for (require_offset, module) in require_calls(trimmed) {
+            imports.push(ImportFact {
+                module,
+                names: Vec::new(),
+                span: span_for_offsets(
+                    &file.relative_path,
+                    &file.text,
+                    start + require_offset,
+                    start + require_offset + "require".len(),
+                ),
+            });
+        }
+    }
+    imports.sort_by(|left, right| {
+        left.span
+            .start
+            .line
+            .cmp(&right.span.start.line)
+            .then(left.module.cmp(&right.module))
+    });
+    imports
+}
+
+fn parse_import_statement(line: &str) -> Option<(String, Vec<String>)> {
+    let line = line.trim_end_matches(';').trim();
+    if let Some(rest) = line.strip_prefix("import type ") {
+        return parse_import_statement(&format!("import {rest}"));
+    }
+    let rest = line.strip_prefix("import ")?;
+    if let Some(module) = quoted_after(rest, "") {
+        return Some((module, Vec::new()));
+    }
+    let from_index = rest.rfind(" from ")?;
+    let bindings = rest[..from_index].trim();
+    let module = quoted_after(rest[from_index + " from ".len()..].trim(), "")?;
+    Some((module, parse_import_names(bindings)))
+}
+
+fn parse_export_from_statement(line: &str) -> Option<(String, Vec<String>)> {
+    let line = line.trim_end_matches(';').trim();
+    let from_index = line.rfind(" from ")?;
+    let module = quoted_after(line[from_index + " from ".len()..].trim(), "")?;
+    let names = if line.contains("* as ") {
+        line.split("* as ")
+            .nth(1)
+            .and_then(|rest| rest.split_whitespace().next())
+            .map(|name| vec![name.trim_end_matches(',').to_owned()])
+            .unwrap_or_else(|| vec!["*".to_owned()])
+    } else if let Some(open) = line.find('{') {
+        let close = line[open + 1..].find('}')? + open + 1;
+        parse_named_list(&line[open + 1..close])
+    } else {
+        Vec::new()
+    };
+    Some((module, names))
+}
+
+fn parse_import_names(bindings: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = bindings.trim();
+    if rest.starts_with('{') {
+        if let Some(close) = rest.find('}') {
+            names.extend(parse_named_list(&rest[1..close]));
+        }
+        return names;
+    }
+    if let Some(default_name) = rest
+        .split(',')
+        .next()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        if !default_name.starts_with('*') {
+            names.push(default_name.to_owned());
+        }
+    }
+    if let Some(namespace_index) = rest.find("* as ") {
+        rest = &rest[namespace_index + "* as ".len()..];
+        if let Some(name) = rest.split_whitespace().next() {
+            names.push(name.trim_end_matches(',').to_owned());
+        }
+    }
+    if let Some(open) = rest.find('{') {
+        if let Some(close) = rest[open + 1..].find('}') {
+            names.extend(parse_named_list(&rest[open + 1..open + 1 + close]));
+        }
+    }
+    names
+}
+
+fn parse_named_list(names: &str) -> Vec<String> {
+    names
+        .split(',')
+        .filter_map(|name| {
+            let name = name
+                .trim()
+                .strip_prefix("type ")
+                .unwrap_or(name.trim())
+                .trim();
+            if name.is_empty() {
+                None
+            } else {
+                Some(
+                    name.split(" as ")
+                        .last()
+                        .unwrap_or(name)
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or(name)
+                        .to_owned(),
+                )
+            }
+        })
+        .collect()
+}
+
+fn require_calls(line: &str) -> Vec<(usize, String)> {
+    let mut calls = Vec::new();
+    let mut search_start = 0;
+    while let Some(relative) = line[search_start..].find("require(") {
+        let start = search_start + relative;
+        if let Some(module) = quoted_after(&line[start + "require(".len()..], "") {
+            calls.push((start, module));
+        }
+        search_start = start + "require(".len();
+    }
+    calls
+}
+
+fn extract_symbols(file: &SourceFile) -> Vec<SymbolFact> {
+    let mut symbols = Vec::new();
+    let mut class_depth = 0usize;
+    for (line_start, line) in line_offsets(&file.text) {
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        let start = line_start + indent;
+        if let Some(name) = function_name(trimmed) {
+            symbols.push(symbol(file, name, SymbolKind::Function, start, trimmed));
+        }
+        if let Some(name) = class_name(trimmed) {
+            symbols.push(symbol(file, name, SymbolKind::Class, start, trimmed));
+        }
+        if let Some(name) = arrow_function_name(trimmed) {
+            symbols.push(symbol(file, name, SymbolKind::Function, start, trimmed));
+        }
+        if class_depth > 0 {
+            if let Some(name) = method_name(trimmed) {
+                symbols.push(symbol(file, name, SymbolKind::Method, start, trimmed));
+            }
+        }
+        class_depth = class_depth.saturating_add(trimmed.matches('{').count());
+        class_depth = class_depth.saturating_sub(trimmed.matches('}').count());
+    }
+    symbols
+}
+
+fn symbol(
+    file: &SourceFile,
+    name: String,
+    kind: SymbolKind,
+    start: usize,
+    text: &str,
+) -> SymbolFact {
+    SymbolFact {
+        name,
+        kind,
+        span: span_for_offsets(&file.relative_path, &file.text, start, start + text.len()),
+    }
+}
+
+fn function_name(line: &str) -> Option<String> {
+    let mut rest = line.strip_prefix("export ").unwrap_or(line);
+    rest = rest.strip_prefix("default ").unwrap_or(rest);
+    rest = rest.strip_prefix("async ").unwrap_or(rest);
+    rest = rest.strip_prefix("function ")?;
+    identifier_prefix(rest)
+}
+
+fn class_name(line: &str) -> Option<String> {
+    let mut rest = line.strip_prefix("export ").unwrap_or(line);
+    rest = rest.strip_prefix("default ").unwrap_or(rest);
+    rest = rest.strip_prefix("class ")?;
+    identifier_prefix(rest)
+}
+
+fn arrow_function_name(line: &str) -> Option<String> {
+    if !line.contains("=>") {
+        return None;
+    }
+    let rest = line
+        .strip_prefix("export ")
+        .unwrap_or(line)
+        .strip_prefix("const ")
+        .or_else(|| line.strip_prefix("let "))
+        .or_else(|| line.strip_prefix("var "))?;
+    identifier_prefix(rest.split('=').next()?.trim())
+}
+
+fn method_name(line: &str) -> Option<String> {
+    if line.starts_with("if ")
+        || line.starts_with("for ")
+        || line.starts_with("while ")
+        || line.starts_with("switch ")
+        || line.starts_with("catch ")
+        || line.starts_with("function ")
+        || line.contains("=>")
+    {
+        return None;
+    }
+    let open = line.find('(')?;
+    let name = line[..open]
+        .split_whitespace()
+        .last()
+        .unwrap_or_default()
+        .trim_start_matches("async ");
+    (!name.is_empty()).then(|| name.to_owned())
+}
+
+fn extract_calls(file: &SourceFile) -> Vec<CallFact> {
+    let text = file.text.as_str();
+    let bytes = text.as_bytes();
+    let mut calls = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !is_identifier_start(bytes[index] as char) {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        index += 1;
+        while index < bytes.len() {
+            let character = bytes[index] as char;
+            if is_identifier_char(character) || character == '.' {
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        let callee = &text[start..index];
+        let after_ws = skip_whitespace(text, index);
+        if after_ws >= bytes.len()
+            || bytes[after_ws] != b'('
+            || is_non_call_context(text, start, callee)
+        {
+            continue;
+        }
+        let end = find_matching_paren(text, after_ws).unwrap_or(after_ws);
+        let arguments = split_arguments(&text[after_ws + 1..end]);
+        calls.push(CallFact {
+            callee: callee.to_owned(),
+            arguments,
+            span: span_for_offsets(&file.relative_path, text, start, end + 1),
+        });
+        index = after_ws + 1;
+    }
+    calls
+}
+
+fn is_non_call_context(text: &str, start: usize, callee: &str) -> bool {
+    let line_start = text[..start].rfind('\n').map_or(0, |index| index + 1);
+    let before = text[line_start..start].trim_end();
+    matches!(
+        callee,
+        "if" | "for" | "while" | "switch" | "catch" | "function" | "return"
+    ) || before.ends_with("function")
+        || before.ends_with("function*")
+        || before.ends_with("class")
+}
+
+fn split_arguments(arguments: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (index, character) in arguments.char_indices() {
+        match character {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let value = arguments[start..index].trim();
+                if !value.is_empty() {
+                    parts.push(value.to_owned());
+                }
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    let value = arguments[start..].trim();
+    if !value.is_empty() {
+        parts.push(value.to_owned());
+    }
+    parts
+}
+
+fn quoted_after(text: &str, _prefix: &str) -> Option<String> {
+    let text = text.trim_start();
+    let quote = text.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let rest = &text[quote.len_utf8()..];
+    let end = rest.find(quote)?;
+    Some(rest[..end].to_owned())
+}
+
+fn identifier_prefix(text: &str) -> Option<String> {
+    let name = text
+        .chars()
+        .take_while(|character| is_identifier_char(*character))
+        .collect::<String>();
+    (!name.is_empty()).then_some(name)
+}
+
+fn line_offsets(text: &str) -> Vec<(usize, &str)> {
+    let mut lines = Vec::new();
+    let mut offset = 0;
+    for line in text.lines() {
+        lines.push((offset, line));
+        offset += line.len() + 1;
+    }
+    lines
+}
+
+fn skip_whitespace(text: &str, mut index: usize) -> usize {
+    while index < text.len() && text.as_bytes()[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    index
+}
+
+fn find_matching_paren(text: &str, open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, character) in text[open..].char_indices() {
+        match character {
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(open + index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn is_identifier_start(character: char) -> bool {
+    character.is_ascii_alphabetic() || character == '_' || character == '$'
+}
+
+fn is_identifier_char(character: char) -> bool {
+    is_identifier_start(character) || character.is_ascii_digit()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(text: &str) -> ParsedFile {
+        TypeScriptAdapter.parse_file(&SourceFile {
+            path: "fixture.ts".into(),
+            relative_path: "fixture.ts".to_owned(),
+            language: Language::TypeScript,
+            text: text.to_owned(),
+        })
+    }
+
+    #[test]
+    fn parses_imports_symbols_calls_and_suppressions() {
+        let parsed = parse(
+            r#"
+import express, { Router as ExpressRouter } from "express";
+export { helper as routeHelper } from "./helpers";
+const prisma = require("@prisma/client");
+
+export async function updateInvoice(id: string) {
+  return prisma.invoice.update({ where: { id } });
+}
+
+const routeHandler = async (req, res) => updateInvoice(req.params.id);
+
+class InvoiceController {
+  async patch(req, res) {
+    await updateInvoice(req.params.id);
+  }
+}
+
+// rulepath-disable-next-line INV001 -- parser test suppression
+router.patch("/:id", routeHandler);
+"#,
+        );
+
+        assert!(parsed
+            .imports
+            .iter()
+            .any(|import| import.module == "express"));
+        assert!(parsed
+            .imports
+            .iter()
+            .any(|import| import.module == "./helpers"));
+        assert!(parsed
+            .imports
+            .iter()
+            .any(|import| import.module == "@prisma/client"));
+        assert!(parsed
+            .symbols
+            .iter()
+            .any(|symbol| symbol.name == "updateInvoice" && symbol.kind == SymbolKind::Function));
+        assert!(parsed
+            .symbols
+            .iter()
+            .any(|symbol| symbol.name == "routeHandler" && symbol.kind == SymbolKind::Function));
+        assert!(parsed
+            .symbols
+            .iter()
+            .any(|symbol| symbol.name == "patch" && symbol.kind == SymbolKind::Method));
+        assert!(parsed
+            .calls
+            .iter()
+            .any(|call| call.callee == "updateInvoice"));
+        assert!(parsed
+            .calls
+            .iter()
+            .any(|call| call.callee == "prisma.invoice.update"));
+        assert_eq!(parsed.suppressions[0].rule_id, "INV001");
+        assert!(parsed.calls.iter().all(|call| call.span.start.line > 0));
+    }
+
+    #[test]
+    fn express_fixture_exposes_route_service_call() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("fixtures/express_prisma/unsafe/src/routes/invoices.ts");
+        let text = std::fs::read_to_string(root).expect("fixture should be readable");
+        let parsed = TypeScriptAdapter.parse_file(&SourceFile {
+            path: "src/routes/invoices.ts".into(),
+            relative_path: "src/routes/invoices.ts".to_owned(),
+            language: Language::TypeScript,
+            text,
+        });
+
+        assert!(parsed
+            .imports
+            .iter()
+            .any(|import| import.module == "../services/invoices"));
+        assert!(parsed
+            .calls
+            .iter()
+            .any(|call| call.callee == "updateInvoice"));
+        assert!(!parsed.calls.is_empty());
+    }
 }

--- a/crates/rulepath_orms/Cargo.toml
+++ b/crates/rulepath_orms/Cargo.toml
@@ -8,7 +8,9 @@ repository.workspace = true
 description = "ORM and data-layer adapter registry for Rulepath."
 
 [dependencies]
+rulepath_config = { path = "../rulepath_config" }
 rulepath_ir = { path = "../rulepath_ir" }
+rulepath_workspace = { path = "../rulepath_workspace" }
 rulepath_parsers = { path = "../rulepath_parsers" }
 
 [lints]

--- a/crates/rulepath_orms/src/lib.rs
+++ b/crates/rulepath_orms/src/lib.rs
@@ -1,4 +1,9 @@
-use rulepath_ir::DataLayer;
+use rulepath_config::ResolvedConfig;
+use rulepath_ir::{
+    DataLayer, FilterFact, MutationFieldFact, OperationFact, OperationType, RouteFact, SourceSpan,
+};
+use rulepath_parsers::ParsedFile;
+use rulepath_workspace::SourceFile;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DataLayerDescriptor {
@@ -6,20 +11,433 @@ pub struct DataLayerDescriptor {
     pub name: &'static str,
 }
 
-#[must_use]
-pub fn built_in_data_layers() -> &'static [DataLayerDescriptor] {
-    &[
-        DataLayerDescriptor {
+pub trait DataLayerAdapter {
+    fn descriptor(&self) -> DataLayerDescriptor;
+    fn extract(
+        &self,
+        file: &SourceFile,
+        parsed: &ParsedFile,
+        config: &ResolvedConfig,
+    ) -> Vec<OperationFact>;
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BuiltInDataLayerAdapter {
+    descriptor: DataLayerDescriptor,
+}
+
+impl DataLayerAdapter for BuiltInDataLayerAdapter {
+    fn descriptor(&self) -> DataLayerDescriptor {
+        self.descriptor
+    }
+
+    fn extract(
+        &self,
+        file: &SourceFile,
+        parsed: &ParsedFile,
+        config: &ResolvedConfig,
+    ) -> Vec<OperationFact> {
+        match self.descriptor.id {
+            DataLayer::Prisma => extract_prisma_operations(file, parsed, config),
+            DataLayer::SqlAlchemy => extract_sqlalchemy_operations(file, parsed, config),
+            DataLayer::DjangoOrm => extract_django_orm_operations(file, config),
+            DataLayer::Unknown => Vec::new(),
+        }
+    }
+}
+
+static BUILT_IN_DATA_LAYER_ADAPTERS: &[BuiltInDataLayerAdapter] = &[
+    BuiltInDataLayerAdapter {
+        descriptor: DataLayerDescriptor {
             id: DataLayer::Prisma,
             name: "prisma",
         },
-        DataLayerDescriptor {
+    },
+    BuiltInDataLayerAdapter {
+        descriptor: DataLayerDescriptor {
             id: DataLayer::SqlAlchemy,
             name: "sqlalchemy",
         },
-        DataLayerDescriptor {
+    },
+    BuiltInDataLayerAdapter {
+        descriptor: DataLayerDescriptor {
             id: DataLayer::DjangoOrm,
             name: "django_orm",
         },
-    ]
+    },
+];
+
+#[must_use]
+pub fn built_in_data_layers() -> Vec<&'static dyn DataLayerAdapter> {
+    BUILT_IN_DATA_LAYER_ADAPTERS
+        .iter()
+        .map(|adapter| adapter as &dyn DataLayerAdapter)
+        .collect()
+}
+
+#[must_use]
+pub fn built_in_data_layer_descriptors() -> Vec<DataLayerDescriptor> {
+    BUILT_IN_DATA_LAYER_ADAPTERS
+        .iter()
+        .map(|adapter| adapter.descriptor())
+        .collect()
+}
+
+#[must_use]
+pub fn extract_export_operations(file: &SourceFile, routes: &[RouteFact]) -> Vec<OperationFact> {
+    let lower_text = file.text.to_ascii_lowercase();
+    let export_like = [
+        "/export",
+        "download",
+        "report",
+        "text/csv",
+        "application/pdf",
+    ];
+    if !export_like.iter().any(|needle| lower_text.contains(needle)) {
+        return Vec::new();
+    }
+    routes
+        .iter()
+        .find(|route| route.span.file_id.as_str() == file.relative_path.as_str())
+        .map(|route| {
+            let operation = if route.path.contains("download") {
+                OperationType::Download
+            } else if route.path.contains("report") {
+                OperationType::Report
+            } else {
+                OperationType::Export
+            };
+            OperationFact {
+                id: format!("sink:export:{}:{}", file.relative_path, route.method),
+                data_layer: DataLayer::Unknown,
+                resource: infer_resource_from_text(&file.text)
+                    .unwrap_or_else(|| "Unknown".to_owned()),
+                operation,
+                method: "response_export".to_owned(),
+                filters: Vec::new(),
+                mutation_fields: Vec::new(),
+                bulk: true,
+                span: route.span.clone(),
+            }
+        })
+        .into_iter()
+        .collect()
+}
+
+fn extract_prisma_operations(
+    file: &SourceFile,
+    parsed: &ParsedFile,
+    config: &ResolvedConfig,
+) -> Vec<OperationFact> {
+    let mut operations = Vec::new();
+    for call in &parsed.calls {
+        let Some(rest) = call.callee.strip_prefix("prisma.") else {
+            continue;
+        };
+        let mut parts = rest.split('.');
+        let Some(model) = parts.next() else {
+            continue;
+        };
+        let Some(method) = parts.next() else {
+            continue;
+        };
+        let Some(operation) = prisma_operation(method) else {
+            continue;
+        };
+        let window = surrounding_window_for_line(&file.text, call.span.start.line, 500);
+        let resource = to_resource_name(model);
+        operations.push(OperationFact {
+            id: format!(
+                "sink:prisma.{model}.{method}:{}:{}",
+                file.relative_path, call.span.start.line
+            ),
+            data_layer: DataLayer::Prisma,
+            resource: resource.clone(),
+            operation,
+            method: format!("prisma.{model}.{method}"),
+            filters: extract_filters(&resource, &window, config, file),
+            mutation_fields: extract_mutation_fields(&window, file),
+            bulk: matches!(
+                operation,
+                OperationType::BulkUpdate | OperationType::BulkDelete
+            ),
+            span: call.span.clone(),
+        });
+    }
+    operations
+}
+
+fn extract_sqlalchemy_operations(
+    file: &SourceFile,
+    parsed: &ParsedFile,
+    config: &ResolvedConfig,
+) -> Vec<OperationFact> {
+    let mut operations = Vec::new();
+    for call in &parsed.calls {
+        let marker = call.callee.as_str();
+        if !matches!(marker, "session.get" | "select" | "update" | "delete") {
+            continue;
+        }
+        let Some(resource) = call
+            .arguments
+            .first()
+            .map(|argument| argument.trim())
+            .filter(|argument| !argument.is_empty())
+        else {
+            continue;
+        };
+        let window = surrounding_window_for_line(&file.text, call.span.start.line, 500);
+        let operation = if marker == "delete" {
+            OperationType::Delete
+        } else if marker == "update"
+            || window.contains("session.commit")
+            || window.contains("body.status")
+        {
+            OperationType::Update
+        } else {
+            OperationType::Read
+        };
+        operations.push(OperationFact {
+            id: format!(
+                "sink:sqlalchemy.{resource}.{marker}:{}:{}",
+                file.relative_path, call.span.start.line
+            ),
+            data_layer: DataLayer::SqlAlchemy,
+            resource: resource.to_owned(),
+            operation,
+            method: marker.to_owned(),
+            filters: extract_filters(resource, &window, config, file),
+            mutation_fields: extract_mutation_fields(&window, file),
+            bulk: marker == "update" || marker == "delete",
+            span: call.span.clone(),
+        });
+    }
+    operations
+}
+
+fn extract_django_orm_operations(file: &SourceFile, config: &ResolvedConfig) -> Vec<OperationFact> {
+    let mut operations = Vec::new();
+    for (offset, _) in file.text.match_indices(".objects.") {
+        let before = &file.text[..offset];
+        let resource = before
+            .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+            .next_back()
+            .unwrap_or_default()
+            .to_owned();
+        if resource.is_empty() {
+            continue;
+        }
+        let after = &file.text[offset + ".objects.".len()..];
+        let method = after
+            .chars()
+            .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+            .collect::<String>();
+        let Some(operation) = django_operation(&method) else {
+            continue;
+        };
+        let line = rulepath_workspace::line_number_for_offset(&file.text, offset);
+        let window = surrounding_window_for_offset(&file.text, offset, 500);
+        operations.push(OperationFact {
+            id: format!(
+                "sink:django_orm.{resource}.{method}:{}:{line}",
+                file.relative_path
+            ),
+            data_layer: DataLayer::DjangoOrm,
+            resource: resource.clone(),
+            operation,
+            method: format!("{resource}.objects.{method}"),
+            filters: extract_filters(&resource, &window, config, file),
+            mutation_fields: extract_mutation_fields(&window, file),
+            bulk: matches!(
+                operation,
+                OperationType::BulkUpdate | OperationType::BulkDelete
+            ),
+            span: SourceSpan::single_line(file.relative_path.as_str(), line),
+        });
+    }
+    operations
+}
+
+fn extract_filters(
+    resource: &str,
+    window: &str,
+    config: &ResolvedConfig,
+    file: &SourceFile,
+) -> Vec<FilterFact> {
+    let mut filters = Vec::new();
+    if contains_id_filter(window) {
+        filters.push(FilterFact {
+            field: "id".to_owned(),
+            value: "request-controlled id".to_owned(),
+            source_id: Some(format!("source:{}:route_param", file.relative_path)),
+        });
+    }
+    for field in config.tenant_fields_for(resource) {
+        if window.contains(&field) {
+            filters.push(FilterFact {
+                field,
+                value: "current principal scope".to_owned(),
+                source_id: None,
+            });
+        }
+    }
+    filters
+}
+
+fn extract_mutation_fields(window: &str, file: &SourceFile) -> Vec<MutationFieldFact> {
+    let mut fields = Vec::new();
+    if window.contains("data: body")
+        || window.contains("data: req.body")
+        || window.contains("data: request.body")
+        || window.contains("request.data")
+    {
+        fields.push(MutationFieldFact {
+            field: "*".to_owned(),
+            value: "request body".to_owned(),
+            source_id: Some(format!("source:{}:body", file.relative_path)),
+        });
+    }
+    for field in [
+        "status",
+        "state",
+        "role",
+        "tenant_id",
+        "tenantId",
+        "amount",
+        "total",
+        "approved_by",
+        "approvedBy",
+    ] {
+        if window.contains(field) && (window.contains("body") || window.contains("request.data")) {
+            fields.push(MutationFieldFact {
+                field: field.to_owned(),
+                value: format!("body.{field}"),
+                source_id: Some(format!("source:{}:body", file.relative_path)),
+            });
+        }
+    }
+    fields
+}
+
+fn contains_id_filter(window: &str) -> bool {
+    window.contains(" id")
+        || window.contains("id:")
+        || window.contains(".id")
+        || window.contains("_id")
+        || window.contains("invoice_id")
+        || window.contains("client_id")
+}
+
+fn surrounding_window_for_line(text: &str, line: usize, radius: usize) -> String {
+    let mut offset = 0;
+    for (index, item) in text.lines().enumerate() {
+        if index + 1 == line {
+            break;
+        }
+        offset += item.len() + 1;
+    }
+    surrounding_window_for_offset(text, offset, radius)
+}
+
+fn surrounding_window_for_offset(text: &str, offset: usize, radius: usize) -> String {
+    let start = offset.saturating_sub(radius);
+    let end = (offset + radius).min(text.len());
+    text[start..end].to_owned()
+}
+
+fn prisma_operation(method: &str) -> Option<OperationType> {
+    match method {
+        "findUnique" | "findFirst" | "findMany" => Some(OperationType::Read),
+        "create" => Some(OperationType::Create),
+        "update" | "upsert" => Some(OperationType::Update),
+        "delete" => Some(OperationType::Delete),
+        "updateMany" => Some(OperationType::BulkUpdate),
+        "deleteMany" => Some(OperationType::BulkDelete),
+        _ => None,
+    }
+}
+
+fn django_operation(method: &str) -> Option<OperationType> {
+    match method {
+        "get" | "filter" | "all" => Some(OperationType::Read),
+        "create" => Some(OperationType::Create),
+        "update" => Some(OperationType::BulkUpdate),
+        "delete" => Some(OperationType::BulkDelete),
+        _ => None,
+    }
+}
+
+fn to_resource_name(model: &str) -> String {
+    let mut characters = model.chars();
+    let Some(first) = characters.next() else {
+        return "Unknown".to_owned();
+    };
+    format!(
+        "{}{}",
+        first.to_ascii_uppercase(),
+        characters.collect::<String>()
+    )
+}
+
+fn infer_resource_from_text(text: &str) -> Option<String> {
+    ["Invoice", "Client", "User", "Order", "Payment"]
+        .iter()
+        .find(|resource| {
+            text.contains(**resource)
+                || text
+                    .to_ascii_lowercase()
+                    .contains(&resource.to_ascii_lowercase())
+        })
+        .map(|resource| (*resource).to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rulepath_ir::{Language, Position};
+    use rulepath_parsers::{CallFact, ParsedFile};
+
+    fn empty_config() -> ResolvedConfig {
+        rulepath_config::default_resolved_config()
+    }
+
+    #[test]
+    fn adapters_are_registered_deterministically() {
+        let descriptors = built_in_data_layer_descriptors();
+        let names = descriptors
+            .iter()
+            .map(|descriptor| descriptor.name)
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["prisma", "sqlalchemy", "django_orm"]);
+    }
+
+    #[test]
+    fn prisma_extraction_uses_parsed_calls() {
+        let file = SourceFile {
+            path: "src/services/invoices.ts".into(),
+            relative_path: "src/services/invoices.ts".to_owned(),
+            language: Language::TypeScript,
+            text: "return prisma.invoice.update({ where: { id }, data: req.body })".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![CallFact {
+                callee: "prisma.invoice.update".to_owned(),
+                arguments: vec!["{ where: { id }, data: req.body }".to_owned()],
+                span: SourceSpan {
+                    file_id: file.relative_path.clone(),
+                    start: Position::new(1, 8),
+                    end: Position::new(1, 40),
+                },
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_prisma_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].resource, "Invoice");
+        assert_eq!(operations[0].operation, OperationType::Update);
+    }
 }

--- a/crates/rulepath_parsers/src/lib.rs
+++ b/crates/rulepath_parsers/src/lib.rs
@@ -66,6 +66,31 @@ pub trait LanguageAdapter {
 }
 
 #[must_use]
+pub fn span_for_offsets(file_id: &str, text: &str, start: usize, end: usize) -> SourceSpan {
+    SourceSpan {
+        file_id: file_id.to_owned(),
+        start: position_for_offset(text, start),
+        end: position_for_offset(text, end),
+    }
+}
+
+#[must_use]
+pub fn position_for_offset(text: &str, offset: usize) -> rulepath_ir::Position {
+    let bounded = offset.min(text.len());
+    let mut line = 1;
+    let mut column = 1;
+    for character in text[..bounded].chars() {
+        if character == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    rulepath_ir::Position::new(line, column)
+}
+
+#[must_use]
 pub fn extract_suppressions_from_text(file_id: &str, text: &str) -> Vec<SuppressionFact> {
     text.lines()
         .enumerate()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,8 +6,9 @@ Rulepath is a Rust workspace organized around fact extraction, normalization, tr
 source files
   -> parser adapters
   -> language facts
-  -> framework adapters
-  -> data-layer adapters
+  -> framework adapter registry
+  -> data-layer adapter registry
+  -> scan context
   -> auth evidence normalization
   -> service-layer tracing
   -> common IR
@@ -47,10 +48,10 @@ Normal scans must stay Rust-native. Optional sidecars may be added later only fo
 1. Load and validate config.
 2. Merge the configured profile.
 3. Build a workspace file index.
-4. Parse source files in parallel.
-5. Extract language facts.
-6. Extract framework route facts.
-7. Extract data-layer sink facts.
+4. Parse supported source files into language facts.
+5. Run framework adapters over parsed facts.
+6. Run data-layer adapters over parsed facts.
+7. Build a scan context from workspace, parsed facts, and extracted IR facts.
 8. Normalize auth evidence.
 9. Trace route-to-sink call paths.
 10. Build common IR.
@@ -58,3 +59,5 @@ Normal scans must stay Rust-native. Optional sidecars may be added later only fo
 12. Evaluate rules.
 13. Apply baseline and CI policy.
 14. Emit reports.
+
+Framework and data-layer extraction is registered by adapter descriptors, so scan orchestration does not need framework-specific or ORM-specific lexical logic. `rulepath_dataflow` owns the scan context, route-to-operation source propagation, and deterministic IR assembly.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -45,4 +45,6 @@ Uncertainty should reduce confidence or produce review hints.
 
 ## Current Trace Foundation
 
-The first analyzer slice builds a conservative trace index from route bodies, simple function spans, and service calls. Sinks discovered in service files are connected back to route request sources when the route calls the enclosing service function. This is intentionally narrow and fixture-backed; deeper parser-backed symbol resolution should replace these heuristics over time.
+The current analyzer builds a conservative trace index from parser-backed symbols and calls. Framework and data-layer adapters consume those parsed facts through deterministic registries, then dataflow connects route request sources to operations when parsed calls cross from route handlers into service functions.
+
+The trace remains intentionally narrow and fixture-backed. Unsupported dynamic dispatch, generated code, or framework behavior should reduce confidence or produce review hints rather than inventing unsupported edges.

--- a/docs/testing-fixtures.md
+++ b/docs/testing-fixtures.md
@@ -22,6 +22,8 @@ fixtures/
 
 Each fixture should be small, readable, and focused on one analysis behavior.
 
+Language adapters also carry parser-level unit coverage for imports, symbols, calls, decorators, and suppressions. Fixture scans should assert the end-to-end path: parser facts, framework route extraction, data-layer operation extraction, trace propagation, and final findings.
+
 ## Required Scenarios
 
 Each fixture family should cover:


### PR DESCRIPTION
## Summary

Implements the full `phase:1-foundation` issue set across three focused commits:

- **#2 TypeScript parser facts**: wires the TypeScript adapter through Oxc parsing and extracts imports, exported imports, CommonJS requires, symbols, calls, argument summaries, spans, and suppressions.
- **#3 Python parser facts**: wires the Python adapter through tree-sitter and extracts imports, functions, methods, classes, decorators, calls, spans, and suppressions.
- **#4 Parsed-fact scan pipeline**: refactors framework and data-layer extraction behind deterministic adapter registries, introduces scan-context-oriented dataflow assembly, and moves framework/ORM-specific interpretation out of `rulepath_dataflow`.

Fixes #2.
Fixes #3.
Fixes #4.

## Implementation Notes

- Added shared parser span helpers for offset-to-position conversion.
- Added parser-backed unit coverage for TypeScript and Python fixture behavior.
- Added framework adapter descriptors and built-in registry coverage for Express, FastAPI, DRF/Django, and Next.js route facts.
- Added data-layer adapter descriptors and built-in registry coverage for Prisma, SQLAlchemy, and Django ORM operation facts.
- Rebuilt dataflow around parsed language facts, extracted framework facts, extracted operation facts, auth evidence, trace indexing, and deterministic IR assembly.
- Updated architecture, implementation notes, and fixture testing docs to reflect the parser-backed registry pipeline.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets`
- `cargo test --locked --workspace`