### PR TITLE
Implement phase 2 existing wedge analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Rulepath is a Rust workspace. Source code lives under `crates/`, with one crate per responsibility: `rulepath_cli` for the binary, `rulepath_config` for `.rulepath.yml`, `rulepath_ir` for normalized facts, `rulepath_parsers` plus `rulepath_lang_*` for parser-backed facts, `rulepath_frameworks` and `rulepath_orms` for adapters, `rulepath_dataflow` for tracing, and `rulepath_rules` for diagnostics. Fixture applications live in `fixtures/`. Built-in profiles live in `profiles/`. Repository documentation lives in `docs/`, with user-facing summaries in `README.md` and release notes in `CHANGELOG.md`.
+
+## Build, Test, and Development Commands
+
+- `cargo build --locked --workspace`: build every crate with the locked dependency graph.
+- `cargo test --locked --workspace`: run unit, integration, fixture, and doc tests.
+- `cargo clippy --locked --workspace --all-targets`: run lint checks used by CI.
+- `cargo fmt --all -- --check`: verify formatting without changing files.
+- `cargo run -p rulepath_cli -- scan fixtures/express_prisma/unsafe`: run the CLI against a representative fixture.
+
+Use `--locked` for verification because dependency versions are pinned in `Cargo.lock`.
+
+## Coding Style & Naming Conventions
+
+Use Rust 2021 and the workspace lint policy in `Cargo.toml`; unsafe code is forbidden. Format with `cargo fmt`. Prefer clear module boundaries matching existing crates instead of adding cross-cutting logic to unrelated layers. Use `snake_case` for functions, modules, and variables; `PascalCase` for types and enum variants. Keep diagnostics, IDs, and fingerprints deterministic by sorting output collections when order can vary.
+
+## Testing Guidelines
+
+Tests use Rust's built-in test framework. Add focused unit tests near the crate that owns the behavior, and add fixture or CLI tests in `crates/rulepath_cli/tests/` for end-to-end scan behavior. Fixture expectations should cover both unsafe and safe examples when changing analysis behavior. Run `cargo test --locked --workspace` before opening a PR.
+
+## Commit & Pull Request Guidelines
+
+Git history uses short imperative commit subjects such as `Implement parser-backed Prisma sinks` or `Normalize config-driven auth evidence`. Keep commits scoped to one issue or behavior. PRs should include a summary, linked issues using `Fixes #N`, documentation changes, and verification commands run. Update `CHANGELOG.md`, `README.md`, or relevant `docs/` pages when behavior, configuration, CLI output, or architecture changes.
+
+## Security & Configuration Tips
+
+Normal scans must remain Rust-native and must not require Python, Node, Docker, network access, or a TypeScript compiler process. Config parsing denies unknown fields; preserve strict validation when adding new settings. Inline suppressions require meaningful reasons by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,8 @@ All notable changes to Rulepath will be documented here.
 - Add initial CLI, config, IR, reporting, rule, inference, and SARIF foundations.
 - Add first-pass route-to-service tracing for Express, FastAPI, and Next.js fixtures.
 - Apply suppression policy before reports, baselines, and CI decisions.
+- Add parser-backed TypeScript and Python facts for imports, symbols, calls, spans, and suppressions.
+- Move Express and FastAPI route extraction into framework adapters with middleware, dependency, handler, and request-source facts.
+- Move Prisma and SQLAlchemy sink extraction into data-layer adapters with parser-backed operations, filters, mutation fields, and bulk operation detection.
+- Normalize configured authentication, authorization, scope, transaction, invariant, and idempotency evidence through `rulepath_auth`.
+- Replace one-hop service tracing with an import- and symbol-aware call graph that respects `analysis.service_layer_tracing` and `analysis.max_call_depth`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,8 @@ version = "0.1.0"
 dependencies = [
  "rulepath_config",
  "rulepath_ir",
+ "rulepath_parsers",
+ "rulepath_workspace",
 ]
 
 [[package]]
@@ -894,6 +896,7 @@ name = "rulepath_dataflow"
 version = "0.1.0"
 dependencies = [
  "petgraph",
+ "rulepath_auth",
  "rulepath_config",
  "rulepath_frameworks",
  "rulepath_ir",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Rulepath v1 targets internally developed web applications:
 
 Normal scans must not require Python, Node, Docker, network access, or a TypeScript compiler process.
 
+## Analysis Model
+
+Rulepath scans source code through Rust-native parser adapters. TypeScript uses Oxc-backed parsing and Python uses tree-sitter-backed parsing to produce normalized facts for imports, symbols, calls, spans, and suppressions.
+
+Framework adapters convert parsed facts into routes, handlers, middleware/dependencies, and request sources. Data-layer adapters convert parsed calls into operations, filters, mutation fields, bulk flags, and sink spans for Prisma, SQLAlchemy, and Django ORM.
+
+Evidence normalization is config-driven. Authentication guards, authorization helpers, tenant expressions, object-scope checks, transaction markers, invariant helpers, and idempotency helpers are normalized before rule evaluation. Service tracing builds an import- and symbol-aware call graph and respects `analysis.service_layer_tracing` and `analysis.max_call_depth`.
+
 ## Build From Source
 
 ```bash

--- a/crates/rulepath_auth/Cargo.toml
+++ b/crates/rulepath_auth/Cargo.toml
@@ -10,6 +10,8 @@ description = "Authentication and authorization evidence normalization for Rulep
 [dependencies]
 rulepath_config = { path = "../rulepath_config" }
 rulepath_ir = { path = "../rulepath_ir" }
+rulepath_parsers = { path = "../rulepath_parsers" }
+rulepath_workspace = { path = "../rulepath_workspace" }
 
 [lints]
 workspace = true

--- a/crates/rulepath_auth/src/lib.rs
+++ b/crates/rulepath_auth/src/lib.rs
@@ -1,5 +1,7 @@
 use rulepath_config::ResolvedConfig;
-use rulepath_ir::EvidenceKind;
+use rulepath_ir::{Confidence, EvidenceFact, EvidenceKind, RouteFact, SourceSpan};
+use rulepath_parsers::ParsedFile;
+use rulepath_workspace::SourceFile;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvidenceClassification {
@@ -7,6 +9,9 @@ pub enum EvidenceClassification {
     Authorization,
     TenantScope,
     ObjectScope,
+    Invariant,
+    Transaction,
+    Idempotency,
     Unknown,
 }
 
@@ -17,6 +22,9 @@ impl From<EvidenceClassification> for Option<EvidenceKind> {
             EvidenceClassification::Authorization => Some(EvidenceKind::Authorization),
             EvidenceClassification::TenantScope => Some(EvidenceKind::TenantScope),
             EvidenceClassification::ObjectScope => Some(EvidenceKind::ObjectScope),
+            EvidenceClassification::Invariant => Some(EvidenceKind::Invariant),
+            EvidenceClassification::Transaction => Some(EvidenceKind::Transaction),
+            EvidenceClassification::Idempotency => Some(EvidenceKind::Idempotency),
             EvidenceClassification::Unknown => None,
         }
     }
@@ -24,28 +32,294 @@ impl From<EvidenceClassification> for Option<EvidenceKind> {
 
 #[must_use]
 pub fn classify_helper(helper: &str, config: &ResolvedConfig) -> EvidenceClassification {
-    let helper = helper.trim();
-    if config
-        .raw
-        .auth
-        .authentication_guards
-        .python
-        .iter()
-        .chain(config.raw.auth.authentication_guards.typescript.iter())
-        .any(|candidate| candidate == helper)
-    {
+    let helper = normalized_helper(helper);
+    if configured_helpers(
+        helper.as_str(),
+        &config.raw.auth.authentication_guards.python,
+        &config.raw.auth.authentication_guards.typescript,
+    ) {
         return EvidenceClassification::Authentication;
     }
-    if config
-        .raw
-        .auth
-        .authorization_functions
-        .python
-        .iter()
-        .chain(config.raw.auth.authorization_functions.typescript.iter())
-        .any(|candidate| candidate == helper)
-    {
+    if configured_helpers(
+        helper.as_str(),
+        &config.raw.auth.authorization_functions.python,
+        &config.raw.auth.authorization_functions.typescript,
+    ) {
         return EvidenceClassification::Authorization;
     }
+    if configured_helpers(
+        helper.as_str(),
+        &config.raw.tenancy.current_tenant_expressions.python,
+        &config.raw.tenancy.current_tenant_expressions.typescript,
+    ) {
+        return EvidenceClassification::TenantScope;
+    }
+    if helper.contains("object") && (helper.contains("permission") || helper.contains("authorize"))
+    {
+        return EvidenceClassification::ObjectScope;
+    }
+    if helper == "commit"
+        || helper.ends_with(".commit")
+        || helper.contains("transaction")
+        || helper == "atomic"
+    {
+        return EvidenceClassification::Transaction;
+    }
+    if helper.contains("idempotency") || helper.contains("idempotent") {
+        return EvidenceClassification::Idempotency;
+    }
+    if config.raw.invariants.iter().any(|invariant| {
+        invariant
+            .requires
+            .iter()
+            .any(|required| normalized_helper(required) == helper)
+    }) {
+        return EvidenceClassification::Invariant;
+    }
     EvidenceClassification::Unknown
+}
+
+#[must_use]
+pub fn normalize_file_evidence(
+    file: &SourceFile,
+    parsed: &ParsedFile,
+    config: &ResolvedConfig,
+) -> Vec<EvidenceFact> {
+    let mut evidence = Vec::new();
+    for call in &parsed.calls {
+        let helper = normalized_helper(call.callee.as_str());
+        if let Some(kind) = Option::<EvidenceKind>::from(classify_helper(helper.as_str(), config)) {
+            evidence.push(evidence_fact(
+                file,
+                &helper,
+                kind,
+                call.callee.clone(),
+                call.span.clone(),
+                None,
+                None,
+                confidence_for(kind, helper.as_str()),
+            ));
+        }
+    }
+    for expression in current_tenant_expressions(config) {
+        for (line_index, line) in file.text.lines().enumerate() {
+            if line.contains(expression.as_str()) {
+                evidence.push(evidence_fact(
+                    file,
+                    expression.as_str(),
+                    EvidenceKind::TenantScope,
+                    expression.clone(),
+                    SourceSpan::single_line(file.relative_path.as_str(), line_index + 1),
+                    None,
+                    None,
+                    Confidence::High,
+                ));
+            }
+        }
+    }
+    evidence.sort_by(|left, right| {
+        left.span
+            .start
+            .line
+            .cmp(&right.span.start.line)
+            .then(left.label.cmp(&right.label))
+    });
+    evidence.dedup_by(|left, right| left.id == right.id);
+    evidence
+}
+
+#[must_use]
+pub fn normalize_route_evidence(
+    routes: &[RouteFact],
+    config: &ResolvedConfig,
+) -> Vec<EvidenceFact> {
+    let mut evidence = Vec::new();
+    for route in routes {
+        for helper in &route.middleware {
+            let normalized = normalized_helper(helper);
+            if let Some(kind) =
+                Option::<EvidenceKind>::from(classify_helper(normalized.as_str(), config))
+            {
+                evidence.push(evidence_fact(
+                    &SourceFile {
+                        path: route.span.file_id.clone().into(),
+                        relative_path: route.span.file_id.clone(),
+                        language: route.language,
+                        text: String::new(),
+                    },
+                    normalized.as_str(),
+                    kind,
+                    helper.clone(),
+                    route.span.clone(),
+                    Some(route.id.clone()),
+                    None,
+                    Confidence::High,
+                ));
+            }
+        }
+    }
+    evidence
+}
+
+fn configured_helpers(helper: &str, python: &[String], typescript: &[String]) -> bool {
+    python
+        .iter()
+        .chain(typescript.iter())
+        .any(|candidate| helper_matches(helper, candidate))
+}
+
+fn helper_matches(helper: &str, candidate: &str) -> bool {
+    let candidate = normalized_helper(candidate);
+    helper == candidate
+        || helper
+            .rsplit('.')
+            .next()
+            .is_some_and(|last| last == candidate)
+}
+
+fn normalized_helper(helper: &str) -> String {
+    helper
+        .trim()
+        .trim_start_matches("Depends(")
+        .trim_end_matches(')')
+        .split('(')
+        .next()
+        .unwrap_or(helper)
+        .trim()
+        .to_owned()
+}
+
+fn current_tenant_expressions(config: &ResolvedConfig) -> Vec<String> {
+    config
+        .raw
+        .tenancy
+        .current_tenant_expressions
+        .python
+        .iter()
+        .chain(
+            config
+                .raw
+                .tenancy
+                .current_tenant_expressions
+                .typescript
+                .iter(),
+        )
+        .cloned()
+        .collect()
+}
+
+fn evidence_fact(
+    file: &SourceFile,
+    helper: &str,
+    kind: EvidenceKind,
+    expression: String,
+    span: SourceSpan,
+    route_id: Option<String>,
+    sink_id: Option<String>,
+    confidence: Confidence,
+) -> EvidenceFact {
+    EvidenceFact {
+        id: format!(
+            "evidence:{}:{}:{}",
+            file.relative_path,
+            span.start.line,
+            label_for(kind, helper)
+        ),
+        kind,
+        label: label_for(kind, helper),
+        expression,
+        confidence,
+        route_id,
+        sink_id,
+        span,
+    }
+}
+
+fn label_for(kind: EvidenceKind, helper: &str) -> String {
+    format!("{}:{helper}", kind_label(kind))
+}
+
+fn kind_label(kind: EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::Authentication => "authentication",
+        EvidenceKind::Authorization => "authorization",
+        EvidenceKind::ObjectScope => "object_scope",
+        EvidenceKind::TenantScope => "tenant_scope",
+        EvidenceKind::OwnershipScope => "ownership_scope",
+        EvidenceKind::Invariant => "invariant",
+        EvidenceKind::Transaction => "transaction",
+        EvidenceKind::Idempotency => "idempotency",
+        EvidenceKind::Audit => "audit",
+    }
+}
+
+fn confidence_for(kind: EvidenceKind, helper: &str) -> Confidence {
+    match kind {
+        EvidenceKind::Transaction | EvidenceKind::Idempotency | EvidenceKind::Invariant => {
+            Confidence::Medium
+        }
+        EvidenceKind::ObjectScope if helper.contains("object") => Confidence::High,
+        EvidenceKind::ObjectScope => Confidence::Medium,
+        _ => Confidence::High,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rulepath_ir::{Language, Position};
+    use rulepath_parsers::CallFact;
+
+    #[test]
+    fn classifies_configured_helpers_across_languages() {
+        let config = rulepath_config::default_resolved_config();
+        assert_eq!(
+            classify_helper("requireAuth", &config),
+            EvidenceClassification::Authentication
+        );
+        assert_eq!(
+            classify_helper("require_permission", &config),
+            EvidenceClassification::Authorization
+        );
+        assert_eq!(
+            classify_helper("req.user.tenantId", &config),
+            EvidenceClassification::TenantScope
+        );
+    }
+
+    #[test]
+    fn normalizes_call_and_tenant_expression_evidence() {
+        let config = rulepath_config::default_resolved_config();
+        let file = SourceFile {
+            path: "src/routes/invoices.ts".into(),
+            relative_path: "src/routes/invoices.ts".to_owned(),
+            language: Language::TypeScript,
+            text: "requirePermission(\"invoice:update\")\nconst clientId = req.user.tenantId\n"
+                .to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![CallFact {
+                callee: "requirePermission".to_owned(),
+                arguments: vec!["\"invoice:update\"".to_owned()],
+                span: SourceSpan {
+                    file_id: file.relative_path.clone(),
+                    start: Position::new(1, 1),
+                    end: Position::new(1, 30),
+                },
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let evidence = normalize_file_evidence(&file, &parsed, &config);
+        assert!(evidence
+            .iter()
+            .any(|item| item.kind == EvidenceKind::Authorization));
+        assert!(evidence
+            .iter()
+            .any(|item| item.kind == EvidenceKind::TenantScope));
+    }
 }

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -165,7 +165,7 @@ fn text_output_shows_call_path_frames() {
     let stdout = run_rulepath(&["scan", path.to_str().expect("utf-8 fixture path")]);
     assert!(stdout.contains("Code path:"));
     assert!(stdout.contains("src/routes/invoices.ts:10 inline_handler()"));
-    assert!(stdout.contains("src/services/invoices.ts:4 updateInvoice()"));
+    assert!(stdout.contains("src/services/invoices.ts:3 updateInvoice()"));
 }
 
 #[test]

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -135,6 +135,31 @@ fn fastapi_service_sink_uses_route_request_sources() {
 }
 
 #[test]
+fn json_output_includes_observed_evidence_labels() {
+    let path = fixture_path("fixtures/express_prisma/unsafe");
+    let stdout = run_rulepath(&[
+        "scan",
+        path.to_str().expect("utf-8 fixture path"),
+        "--format",
+        "json",
+    ]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json output should parse");
+    let finding = json["findings"]
+        .as_array()
+        .expect("findings should be an array")
+        .iter()
+        .find(|finding| finding["rule_id"] == "INV001")
+        .expect("INV001 should be emitted");
+    let observed = finding["observed_evidence"]
+        .as_array()
+        .expect("observed evidence should be an array")
+        .iter()
+        .map(|value| value.as_str().expect("evidence label should be a string"))
+        .collect::<Vec<_>>();
+    assert!(observed.contains(&"authentication:requireAuth"));
+}
+
+#[test]
 fn text_output_shows_call_path_frames() {
     let path = fixture_path("fixtures/express_prisma/unsafe");
     let stdout = run_rulepath(&["scan", path.to_str().expect("utf-8 fixture path")]);

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -163,9 +163,11 @@ fn json_output_includes_observed_evidence_labels() {
 fn text_output_shows_call_path_frames() {
     let path = fixture_path("fixtures/express_prisma/unsafe");
     let stdout = run_rulepath(&["scan", path.to_str().expect("utf-8 fixture path")]);
+    let normalized = stdout.replace('\\', "/");
     assert!(stdout.contains("Code path:"));
-    assert!(stdout.contains("src/routes/invoices.ts:10 inline_handler()"));
-    assert!(stdout.contains("src/services/invoices.ts:3 updateInvoice()"));
+    assert!(normalized.contains("src/routes/invoices.ts:10 inline_handler()"));
+    assert!(normalized.contains("src/services/invoices.ts:"));
+    assert!(normalized.contains("updateInvoice()"));
 }
 
 #[test]

--- a/crates/rulepath_dataflow/Cargo.toml
+++ b/crates/rulepath_dataflow/Cargo.toml
@@ -9,6 +9,7 @@ description = "Route-to-sink tracing and initial IR construction for Rulepath."
 
 [dependencies]
 petgraph.workspace = true
+rulepath_auth = { path = "../rulepath_auth" }
 rulepath_config = { path = "../rulepath_config" }
 rulepath_frameworks = { path = "../rulepath_frameworks" }
 rulepath_ir = { path = "../rulepath_ir" }

--- a/crates/rulepath_dataflow/src/lib.rs
+++ b/crates/rulepath_dataflow/src/lib.rs
@@ -23,7 +23,7 @@ pub fn build_project_ir(index: &WorkspaceIndex, config: &ResolvedConfig) -> Proj
 
     let trace_index = build_trace_index(context.index, &context.parsed_files, &context.ir);
     attach_route_evidence(&mut context.ir);
-    attach_call_paths(&mut context.ir, &trace_index);
+    attach_call_paths(&mut context.ir, &trace_index, config);
     rewrite_operation_sources_to_route_sources(&mut context.ir);
     sort_project_ir(&mut context.ir);
     context.ir
@@ -116,29 +116,18 @@ fn attach_route_evidence(ir: &mut ProjectIr) {
     }
 }
 
-fn attach_call_paths(ir: &mut ProjectIr, trace_index: &TraceIndex) {
+fn attach_call_paths(ir: &mut ProjectIr, trace_index: &TraceIndex, config: &ResolvedConfig) {
     for operation in &ir.operations {
         let operation_function = trace_index.function_for_span(&operation.span);
         let Some(route_match) =
-            find_route_for_operation(ir, trace_index, operation, operation_function)
+            find_route_for_operation(ir, trace_index, operation, operation_function, config)
         else {
             continue;
         };
         let route = route_match.route;
-        let mut frames = vec![CallFrame {
-            function: route.handler.clone(),
-            file: route.span.file_id.clone(),
-            line: route.span.start.line,
-        }];
-        if operation.span.file_id.as_str() != route.span.file_id.as_str() {
-            frames.push(CallFrame {
-                function: operation_function
-                    .map(|function| function.name.clone())
-                    .unwrap_or_else(|| "service_or_repository".to_owned()),
-                file: operation.span.file_id.clone(),
-                line: operation.span.start.line,
-            });
-        }
+        let frames = route_match
+            .frames
+            .unwrap_or_else(|| fallback_frames(route, operation, operation_function));
         ir.call_paths.push(CallPath {
             id: format!("callpath:{}:{}", route.id, operation.id),
             route_id: route.id.clone(),
@@ -207,6 +196,7 @@ fn find_route_for_operation<'a>(
     trace_index: &TraceIndex,
     operation: &OperationFact,
     operation_function: Option<&FunctionSpan>,
+    config: &ResolvedConfig,
 ) -> Option<RouteMatch<'a>> {
     if let Some(route) = ir
         .routes
@@ -216,45 +206,67 @@ fn find_route_for_operation<'a>(
         return Some(RouteMatch {
             route,
             confidence: Confidence::High,
+            frames: None,
         });
     }
 
+    if !config.raw.analysis.service_layer_tracing {
+        return None;
+    }
+
     if let Some(function) = operation_function {
-        if let Some(route_call) = trace_index.route_calls.iter().find(|call| {
-            call.callee == function.name
-                || call
-                    .callee
-                    .rsplit('.')
-                    .next()
-                    .is_some_and(|last_segment| last_segment == function.name)
-        }) {
+        if let Some(route_trace) =
+            trace_index.find_route_trace(function, config.raw.analysis.max_call_depth)
+        {
             return ir
                 .routes
                 .iter()
-                .find(|route| route.id == route_call.route_id)
+                .find(|route| route.id == route_trace.route_id)
                 .map(|route| RouteMatch {
                     route,
                     confidence: Confidence::High,
+                    frames: Some(route_trace.frames),
                 });
         }
     }
-
-    ir.routes.first().map(|route| RouteMatch {
-        route,
-        confidence: Confidence::Low,
-    })
+    None
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+fn fallback_frames(
+    route: &RouteFact,
+    operation: &OperationFact,
+    operation_function: Option<&FunctionSpan>,
+) -> Vec<CallFrame> {
+    let mut frames = vec![CallFrame {
+        function: route.handler.clone(),
+        file: route.span.file_id.clone(),
+        line: route.span.start.line,
+    }];
+    if operation.span.file_id.as_str() != route.span.file_id.as_str() {
+        frames.push(CallFrame {
+            function: operation_function
+                .map(|function| function.name.clone())
+                .unwrap_or_else(|| "service_or_repository".to_owned()),
+            file: operation.span.file_id.clone(),
+            line: operation.span.start.line,
+        });
+    }
+    frames
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct RouteMatch<'a> {
     route: &'a RouteFact,
     confidence: Confidence,
+    frames: Option<Vec<CallFrame>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TraceIndex {
     functions: Vec<FunctionSpan>,
     route_calls: Vec<RouteCall>,
+    function_calls: Vec<FunctionCall>,
+    imports: Vec<ResolvedImport>,
 }
 
 impl TraceIndex {
@@ -264,6 +276,108 @@ impl TraceIndex {
                 && function.start_line <= span.start.line
                 && function.end_line >= span.start.line
         })
+    }
+
+    fn find_route_trace(&self, target: &FunctionSpan, max_depth: usize) -> Option<RouteTrace> {
+        let mut matches = Vec::new();
+        for route_call in &self.route_calls {
+            for candidate in self.resolve_callee(&route_call.file_id, &route_call.callee) {
+                let frames = vec![route_call.frame.clone(), function_frame(candidate)];
+                self.walk_function(
+                    candidate,
+                    target,
+                    max_depth,
+                    frames,
+                    &mut Vec::new(),
+                    &mut matches,
+                    route_call.route_id.clone(),
+                );
+            }
+        }
+        matches.sort_by(|left, right| {
+            left.route_id
+                .cmp(&right.route_id)
+                .then(left.frames.len().cmp(&right.frames.len()))
+        });
+        matches.into_iter().next()
+    }
+
+    fn walk_function(
+        &self,
+        current: &FunctionSpan,
+        target: &FunctionSpan,
+        remaining_depth: usize,
+        frames: Vec<CallFrame>,
+        visited: &mut Vec<String>,
+        matches: &mut Vec<RouteTrace>,
+        route_id: String,
+    ) {
+        if current == target {
+            matches.push(RouteTrace { route_id, frames });
+            return;
+        }
+        if remaining_depth == 0 {
+            return;
+        }
+        let current_key = current.key();
+        if visited.iter().any(|item| item == &current_key) {
+            return;
+        }
+        visited.push(current_key);
+        for call in self
+            .function_calls
+            .iter()
+            .filter(|call| call.caller == *current)
+        {
+            for next in self.resolve_callee(&call.caller.file_id, &call.callee) {
+                let mut next_frames = frames.clone();
+                next_frames.push(function_frame(next));
+                self.walk_function(
+                    next,
+                    target,
+                    remaining_depth.saturating_sub(1),
+                    next_frames,
+                    visited,
+                    matches,
+                    route_id.clone(),
+                );
+            }
+        }
+        visited.pop();
+    }
+
+    fn resolve_callee(&self, caller_file: &str, callee: &str) -> Vec<&FunctionSpan> {
+        let last = callee.rsplit('.').next().unwrap_or(callee);
+        let mut candidates = self
+            .functions
+            .iter()
+            .filter(|function| function.file_id == caller_file && function.name == last)
+            .collect::<Vec<_>>();
+        for import in self
+            .imports
+            .iter()
+            .filter(|import| import.file_id == caller_file)
+        {
+            if import.local_name == callee || import.local_name == last {
+                candidates.extend(self.functions.iter().filter(|function| {
+                    function.file_id == import.target_file_id
+                        && (import.imported_name.as_deref() == Some(function.name.as_str())
+                            || function.name == last
+                            || import.imported_name.is_none())
+                }));
+            } else if callee.starts_with(&format!("{}.", import.local_name)) {
+                candidates.extend(self.functions.iter().filter(|function| {
+                    function.file_id == import.target_file_id && function.name == last
+                }));
+            }
+        }
+        candidates.sort_by(|left, right| {
+            left.file_id
+                .cmp(&right.file_id)
+                .then(left.name.cmp(&right.name))
+        });
+        candidates.dedup_by(|left, right| left.file_id == right.file_id && left.name == right.name);
+        candidates
     }
 }
 
@@ -275,10 +389,38 @@ struct FunctionSpan {
     end_line: usize,
 }
 
+impl FunctionSpan {
+    fn key(&self) -> String {
+        format!("{}:{}:{}", self.file_id, self.name, self.start_line)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RouteCall {
     route_id: String,
+    file_id: String,
     callee: String,
+    frame: CallFrame,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FunctionCall {
+    caller: FunctionSpan,
+    callee: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedImport {
+    file_id: String,
+    local_name: String,
+    imported_name: Option<String>,
+    target_file_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RouteTrace {
+    route_id: String,
+    frames: Vec<CallFrame>,
 }
 
 fn build_trace_index(
@@ -302,9 +444,19 @@ fn build_trace_index(
         })
         .flatten()
         .collect::<Vec<_>>();
+    let function_calls = parsed_files
+        .iter()
+        .flat_map(|parsed| extract_function_calls(parsed, &functions))
+        .collect::<Vec<_>>();
+    let imports = parsed_files
+        .iter()
+        .flat_map(|parsed| resolve_imports(parsed, index))
+        .collect::<Vec<_>>();
     TraceIndex {
         functions,
         route_calls,
+        function_calls,
+        imports,
     }
 }
 
@@ -341,6 +493,32 @@ fn assign_function_ends(index: &WorkspaceIndex, functions: &mut [FunctionSpan]) 
     }
 }
 
+fn extract_function_calls(parsed: &ParsedFile, functions: &[FunctionSpan]) -> Vec<FunctionCall> {
+    let file_functions = functions
+        .iter()
+        .filter(|function| function.file_id == parsed.file_id)
+        .collect::<Vec<_>>();
+    parsed
+        .calls
+        .iter()
+        .filter(|call| is_trace_candidate(call.callee.as_str()))
+        .filter_map(|call| {
+            let caller = file_functions
+                .iter()
+                .find(|function| {
+                    function.start_line <= call.span.start.line
+                        && function.end_line >= call.span.start.line
+                })?
+                .to_owned()
+                .clone();
+            Some(FunctionCall {
+                caller,
+                callee: call.callee.clone(),
+            })
+        })
+        .collect()
+}
+
 fn extract_route_calls(parsed: &ParsedFile, route: &RouteFact) -> Vec<RouteCall> {
     let max_line = route.span.start.line.saturating_add(40);
     parsed
@@ -352,9 +530,134 @@ fn extract_route_calls(parsed: &ParsedFile, route: &RouteFact) -> Vec<RouteCall>
         .filter(|call| is_trace_candidate(call.callee.as_str()))
         .map(|call| RouteCall {
             route_id: route.id.clone(),
+            file_id: route.span.file_id.clone(),
             callee: call.callee.clone(),
+            frame: CallFrame {
+                function: route.handler.clone(),
+                file: route.span.file_id.clone(),
+                line: route.span.start.line,
+            },
         })
         .collect()
+}
+
+fn resolve_imports(parsed: &ParsedFile, index: &WorkspaceIndex) -> Vec<ResolvedImport> {
+    let mut resolved = Vec::new();
+    for import in &parsed.imports {
+        let target_file_id =
+            resolve_module_path(parsed.file_id.as_str(), import.module.as_str(), index);
+        if import.names.is_empty() {
+            let Some(target_file_id) = target_file_id else {
+                continue;
+            };
+            if let Some(local_name) = module_local_name(import.module.as_str()) {
+                resolved.push(ResolvedImport {
+                    file_id: parsed.file_id.clone(),
+                    local_name,
+                    imported_name: None,
+                    target_file_id,
+                });
+            }
+            continue;
+        }
+        for name in &import.names {
+            let imported_module_target = if import.module == "." || import.module.ends_with('.') {
+                resolve_module_path(
+                    parsed.file_id.as_str(),
+                    &format!("{}{}", import.module, name),
+                    index,
+                )
+            } else {
+                None
+            };
+            let Some(target_file_id) = imported_module_target
+                .clone()
+                .or_else(|| target_file_id.clone())
+            else {
+                continue;
+            };
+            resolved.push(ResolvedImport {
+                file_id: parsed.file_id.clone(),
+                local_name: name.clone(),
+                imported_name: imported_module_target.is_none().then(|| name.clone()),
+                target_file_id,
+            });
+        }
+    }
+    resolved
+}
+
+fn resolve_module_path(
+    importer_file_id: &str,
+    module: &str,
+    index: &WorkspaceIndex,
+) -> Option<String> {
+    if !module.starts_with('.') {
+        return None;
+    }
+    let importer_dir = importer_file_id.rsplit_once('/').map_or("", |(dir, _)| dir);
+    let mut parts = importer_dir
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    let normalized_module = normalize_relative_module(module);
+    for part in normalized_module.split('/') {
+        match part {
+            "." | "" => {}
+            ".." => {
+                parts.pop();
+            }
+            item => parts.push(item),
+        }
+    }
+    let stem = parts.join("/");
+    [
+        format!("{stem}.ts"),
+        format!("{stem}.tsx"),
+        format!("{stem}.js"),
+        format!("{stem}.jsx"),
+        format!("{stem}.py"),
+        format!("{stem}/index.ts"),
+        format!("{stem}/index.tsx"),
+        format!("{stem}/__init__.py"),
+    ]
+    .into_iter()
+    .find(|candidate| {
+        index
+            .files
+            .iter()
+            .any(|file| file.relative_path == *candidate)
+    })
+}
+
+fn normalize_relative_module(module: &str) -> String {
+    let leading_dots = module
+        .chars()
+        .take_while(|character| *character == '.')
+        .count();
+    let rest = module[leading_dots..].replace('.', "/");
+    let dots = ".".repeat(leading_dots);
+    if rest.is_empty() || rest.starts_with('/') {
+        format!("{dots}{rest}")
+    } else {
+        format!("{dots}/{rest}")
+    }
+}
+
+fn module_local_name(module: &str) -> Option<String> {
+    module
+        .trim_matches('.')
+        .rsplit(['/', '.'])
+        .find(|segment| !segment.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn function_frame(function: &FunctionSpan) -> CallFrame {
+    CallFrame {
+        function: function.name.clone(),
+        file: function.file_id.clone(),
+        line: function.start_line,
+    }
 }
 
 fn is_trace_candidate(callee: &str) -> bool {
@@ -399,8 +702,8 @@ fn span_key(span: &SourceSpan) -> (&str, usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rulepath_ir::{Language, Position};
-    use rulepath_parsers::{CallFact, SymbolFact};
+    use rulepath_ir::{DataLayer, Language, OperationFact, OperationType, Position};
+    use rulepath_parsers::{CallFact, ImportFact, SymbolFact};
     use rulepath_workspace::SourceFile;
 
     #[test]
@@ -472,6 +775,186 @@ mod tests {
         let trace = build_trace_index(&index, &[parsed], &ir);
         assert_eq!(trace.functions[0].name, "routeHandler");
         assert_eq!(trace.route_calls[0].callee, "updateInvoice");
+    }
+
+    #[test]
+    fn call_graph_resolves_imports_and_two_hop_paths() {
+        let index = WorkspaceIndex {
+            root: ".".into(),
+            files: vec![
+                SourceFile {
+                    path: "src/routes/invoices.ts".into(),
+                    relative_path: "src/routes/invoices.ts".to_owned(),
+                    language: Language::TypeScript,
+                    text: "router.patch('/x', () => updateInvoice())\n".to_owned(),
+                },
+                SourceFile {
+                    path: "src/services/invoices.ts".into(),
+                    relative_path: "src/services/invoices.ts".to_owned(),
+                    language: Language::TypeScript,
+                    text: "import { writeInvoice } from '../repositories/invoices'\n\nfunction updateInvoice() {\n  writeInvoice()\n}\n".to_owned(),
+                },
+                SourceFile {
+                    path: "src/repositories/invoices.ts".into(),
+                    relative_path: "src/repositories/invoices.ts".to_owned(),
+                    language: Language::TypeScript,
+                    text: "function writeInvoice() {\n  prisma.invoice.update()\n}\n".to_owned(),
+                },
+            ],
+        };
+        let parsed = vec![
+            ParsedFile {
+                language: Language::TypeScript,
+                file_id: "src/routes/invoices.ts".to_owned(),
+                imports: vec![ImportFact {
+                    module: "../services/invoices".to_owned(),
+                    names: vec!["updateInvoice".to_owned()],
+                    span: SourceSpan::single_line("src/routes/invoices.ts", 1),
+                }],
+                symbols: Vec::new(),
+                calls: vec![CallFact {
+                    callee: "updateInvoice".to_owned(),
+                    arguments: Vec::new(),
+                    span: SourceSpan::single_line("src/routes/invoices.ts", 5),
+                }],
+                suppressions: Vec::new(),
+            },
+            ParsedFile {
+                language: Language::TypeScript,
+                file_id: "src/services/invoices.ts".to_owned(),
+                imports: vec![ImportFact {
+                    module: "../repositories/invoices".to_owned(),
+                    names: vec!["writeInvoice".to_owned()],
+                    span: SourceSpan::single_line("src/services/invoices.ts", 1),
+                }],
+                symbols: vec![SymbolFact {
+                    name: "updateInvoice".to_owned(),
+                    kind: SymbolKind::Function,
+                    span: SourceSpan::single_line("src/services/invoices.ts", 3),
+                }],
+                calls: vec![CallFact {
+                    callee: "writeInvoice".to_owned(),
+                    arguments: Vec::new(),
+                    span: SourceSpan::single_line("src/services/invoices.ts", 4),
+                }],
+                suppressions: Vec::new(),
+            },
+            ParsedFile {
+                language: Language::TypeScript,
+                file_id: "src/repositories/invoices.ts".to_owned(),
+                imports: Vec::new(),
+                symbols: vec![SymbolFact {
+                    name: "writeInvoice".to_owned(),
+                    kind: SymbolKind::Function,
+                    span: SourceSpan::single_line("src/repositories/invoices.ts", 2),
+                }],
+                calls: Vec::new(),
+                suppressions: Vec::new(),
+            },
+        ];
+        let ir = ProjectIr {
+            routes: vec![RouteFact {
+                id: "route:test".to_owned(),
+                framework: rulepath_ir::Framework::Express,
+                language: Language::TypeScript,
+                method: "PATCH".to_owned(),
+                path: "/invoices/:id".to_owned(),
+                handler: "inline_handler".to_owned(),
+                span: SourceSpan::single_line("src/routes/invoices.ts", 4),
+                middleware: Vec::new(),
+                sources: Vec::new(),
+            }],
+            operations: vec![OperationFact {
+                id: "sink:test".to_owned(),
+                data_layer: DataLayer::Prisma,
+                resource: "Invoice".to_owned(),
+                operation: OperationType::Update,
+                method: "prisma.invoice.update".to_owned(),
+                filters: Vec::new(),
+                mutation_fields: Vec::new(),
+                bulk: false,
+                span: SourceSpan::single_line("src/repositories/invoices.ts", 3),
+            }],
+            ..ProjectIr::default()
+        };
+
+        let trace = build_trace_index(&index, &parsed, &ir);
+        let operation_function = trace
+            .function_for_span(&ir.operations[0].span)
+            .expect("operation should be inside repository function");
+        let route_trace = trace
+            .find_route_trace(operation_function, 2)
+            .expect("two-hop route trace should resolve");
+        assert_eq!(
+            route_trace
+                .frames
+                .iter()
+                .map(|frame| frame.function.as_str())
+                .collect::<Vec<_>>(),
+            vec!["inline_handler", "updateInvoice", "writeInvoice"]
+        );
+        assert!(trace.find_route_trace(operation_function, 0).is_none());
+    }
+
+    #[test]
+    fn service_layer_tracing_can_be_disabled() {
+        let mut config = rulepath_config::default_resolved_config();
+        config.raw.analysis.service_layer_tracing = false;
+        let ir = ProjectIr {
+            routes: vec![RouteFact {
+                id: "route:test".to_owned(),
+                framework: rulepath_ir::Framework::Express,
+                language: Language::TypeScript,
+                method: "PATCH".to_owned(),
+                path: "/invoices/:id".to_owned(),
+                handler: "inline_handler".to_owned(),
+                span: SourceSpan::single_line("src/routes/invoices.ts", 4),
+                middleware: Vec::new(),
+                sources: Vec::new(),
+            }],
+            operations: vec![OperationFact {
+                id: "sink:test".to_owned(),
+                data_layer: DataLayer::Prisma,
+                resource: "Invoice".to_owned(),
+                operation: OperationType::Update,
+                method: "prisma.invoice.update".to_owned(),
+                filters: Vec::new(),
+                mutation_fields: Vec::new(),
+                bulk: false,
+                span: SourceSpan::single_line("src/services/invoices.ts", 3),
+            }],
+            ..ProjectIr::default()
+        };
+        let trace = TraceIndex {
+            functions: vec![FunctionSpan {
+                file_id: "src/services/invoices.ts".to_owned(),
+                name: "updateInvoice".to_owned(),
+                start_line: 1,
+                end_line: 5,
+            }],
+            route_calls: vec![RouteCall {
+                route_id: "route:test".to_owned(),
+                file_id: "src/routes/invoices.ts".to_owned(),
+                callee: "updateInvoice".to_owned(),
+                frame: CallFrame {
+                    function: "inline_handler".to_owned(),
+                    file: "src/routes/invoices.ts".to_owned(),
+                    line: 4,
+                },
+            }],
+            function_calls: Vec::new(),
+            imports: Vec::new(),
+        };
+        let operation_function = trace.function_for_span(&ir.operations[0].span);
+
+        assert!(find_route_for_operation(
+            &ir,
+            &trace,
+            &ir.operations[0],
+            operation_function,
+            &config
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/rulepath_dataflow/src/lib.rs
+++ b/crates/rulepath_dataflow/src/lib.rs
@@ -18,7 +18,7 @@ pub fn build_project_ir(index: &WorkspaceIndex, config: &ResolvedConfig) -> Proj
         ir: ProjectIr::default(),
     };
 
-    collect_framework_and_auth_facts(&mut context);
+    collect_framework_and_auth_facts(&mut context, config);
     collect_operation_facts(&mut context, config);
 
     let trace_index = build_trace_index(context.index, &context.parsed_files, &context.ir);
@@ -50,7 +50,7 @@ fn built_in_language_adapters() -> Vec<Box<dyn LanguageAdapter>> {
     ]
 }
 
-fn collect_framework_and_auth_facts(context: &mut ScanContext<'_>) {
+fn collect_framework_and_auth_facts(context: &mut ScanContext<'_>, config: &ResolvedConfig) {
     for file in &context.index.files {
         let Some(parsed) = parsed_for_file(&context.parsed_files, &file.relative_path) else {
             continue;
@@ -64,8 +64,15 @@ fn collect_framework_and_auth_facts(context: &mut ScanContext<'_>) {
         context
             .ir
             .evidence
-            .extend(rulepath_frameworks::extract_auth_evidence(file, parsed));
+            .extend(rulepath_auth::normalize_file_evidence(file, parsed, config));
     }
+    context
+        .ir
+        .evidence
+        .extend(rulepath_auth::normalize_route_evidence(
+            &context.ir.routes,
+            config,
+        ));
 }
 
 fn collect_operation_facts(context: &mut ScanContext<'_>, config: &ResolvedConfig) {

--- a/crates/rulepath_frameworks/src/lib.rs
+++ b/crates/rulepath_frameworks/src/lib.rs
@@ -200,13 +200,16 @@ fn extract_express(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) 
         let Some(path) = call.arguments.first().and_then(|arg| literal_argument(arg)) else {
             continue;
         };
+        let middleware = express_middleware(&call.arguments);
+        let handler = express_handler(&call.arguments);
         push_route(
             file,
             &mut facts,
             Framework::Express,
             method.to_owned(),
             path,
-            "inline_handler".to_owned(),
+            handler,
+            middleware,
             call.span.clone(),
             route_offset,
         );
@@ -232,6 +235,7 @@ fn extract_fastapi(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) 
             .find(|symbol| symbol.span.start.line > call.span.start.line)
             .map(|symbol| symbol.name.clone())
             .unwrap_or_else(|| "fastapi_handler".to_owned());
+        let middleware = fastapi_dependencies(file, parsed, call.span.start.line, handler.as_str());
         push_route(
             file,
             &mut facts,
@@ -239,6 +243,7 @@ fn extract_fastapi(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) 
             method.to_owned(),
             path,
             handler,
+            middleware,
             call.span.clone(),
             route_offset,
         );
@@ -265,6 +270,7 @@ fn extract_nextjs(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) -
                 symbol.name.clone(),
                 path_from_nextjs_file(file.relative_path.as_str()),
                 symbol.name.clone(),
+                Vec::new(),
                 symbol.span.clone(),
                 route_offset,
             );
@@ -287,6 +293,7 @@ fn extract_django_rest_framework(file: &SourceFile, route_offset: usize) -> Fram
                 "GET".to_owned(),
                 inferred_django_path(file),
                 class_name_from_line(line).unwrap_or_else(|| "drf_view".to_owned()),
+                django_permission_classes(line),
                 SourceSpan::single_line(file.relative_path.as_str(), line_index + 1),
                 route_offset,
             );
@@ -302,6 +309,7 @@ fn push_route(
     method: String,
     path: String,
     handler: String,
+    middleware: Vec<String>,
     span: SourceSpan,
     route_offset: usize,
 ) {
@@ -322,7 +330,7 @@ fn push_route(
     facts.sources.push(SourceFact {
         id: param_source.clone(),
         kind: SourceKind::RouteParam,
-        name: "id".to_owned(),
+        name: route_param_name(framework, path.as_str()).unwrap_or_else(|| "id".to_owned()),
         expression: param_expression(framework),
         controlled_by_request: true,
         span: span.clone(),
@@ -335,9 +343,137 @@ fn push_route(
         path,
         handler,
         span,
-        middleware: Vec::new(),
+        middleware,
         sources: vec![param_source, body_source],
     });
+}
+
+fn express_middleware(arguments: &[String]) -> Vec<String> {
+    if arguments.len() <= 2 {
+        return Vec::new();
+    }
+    arguments[1..arguments.len() - 1]
+        .iter()
+        .filter_map(|argument| middleware_name(argument))
+        .collect()
+}
+
+fn express_handler(arguments: &[String]) -> String {
+    arguments
+        .last()
+        .and_then(|argument| {
+            let trimmed = argument.trim();
+            if trimmed.contains("=>")
+                || trimmed.starts_with("function")
+                || trimmed.starts_with("async (")
+            {
+                Some("inline_handler".to_owned())
+            } else {
+                middleware_name(trimmed)
+            }
+        })
+        .unwrap_or_else(|| "inline_handler".to_owned())
+}
+
+fn fastapi_dependencies(
+    file: &SourceFile,
+    parsed: &ParsedFile,
+    decorator_line: usize,
+    handler: &str,
+) -> Vec<String> {
+    let handler_end = parsed
+        .symbols
+        .iter()
+        .filter(|symbol| symbol.span.start.line > decorator_line)
+        .nth(1)
+        .map_or(decorator_line + 20, |symbol| {
+            symbol.span.start.line.saturating_sub(1)
+        });
+    let mut dependencies = parsed
+        .calls
+        .iter()
+        .filter(|call| call.callee == "Depends")
+        .filter(|call| {
+            call.span.start.line >= decorator_line && call.span.start.line <= handler_end
+        })
+        .filter_map(|call| call.arguments.first())
+        .filter_map(|argument| middleware_name(argument))
+        .collect::<Vec<_>>();
+    if dependencies.is_empty() {
+        if let Some(signature) = function_signature_line(file, handler) {
+            dependencies.extend(depends_names_from_text(signature));
+        }
+    }
+    dependencies.sort();
+    dependencies.dedup();
+    dependencies
+}
+
+fn function_signature_line<'a>(file: &'a SourceFile, handler: &str) -> Option<&'a str> {
+    file.text.lines().find(|line| {
+        line.trim_start().starts_with(&format!("def {handler}("))
+            || line
+                .trim_start()
+                .starts_with(&format!("async def {handler}("))
+    })
+}
+
+fn depends_names_from_text(text: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = text;
+    while let Some(index) = rest.find("Depends(") {
+        rest = &rest[index + "Depends(".len()..];
+        if let Some(name) = middleware_name(rest) {
+            names.push(name);
+        }
+    }
+    names
+}
+
+fn middleware_name(argument: &str) -> Option<String> {
+    let trimmed = argument
+        .trim()
+        .trim_start_matches("Depends(")
+        .trim_end_matches(')')
+        .trim();
+    let name = trimmed
+        .split('(')
+        .next()
+        .unwrap_or(trimmed)
+        .split(|character: char| {
+            !(character.is_ascii_alphanumeric() || character == '_' || character == '.')
+        })
+        .next()
+        .unwrap_or_default()
+        .trim();
+    (!name.is_empty()).then(|| name.rsplit('.').next().unwrap_or(name).to_owned())
+}
+
+fn route_param_name(framework: Framework, path: &str) -> Option<String> {
+    match framework {
+        Framework::FastApi | Framework::Django | Framework::DjangoRestFramework => path
+            .split('{')
+            .nth(1)
+            .and_then(|rest| rest.split('}').next())
+            .map(ToOwned::to_owned),
+        _ => path
+            .split(':')
+            .nth(1)
+            .map(|rest| {
+                rest.chars()
+                    .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+                    .collect::<String>()
+            })
+            .filter(|name| !name.is_empty()),
+    }
+}
+
+fn django_permission_classes(line: &str) -> Vec<String> {
+    if line.contains("permission_classes") {
+        vec!["permission_classes".to_owned()]
+    } else {
+        Vec::new()
+    }
 }
 
 fn express_method(callee: &str) -> Option<&'static str> {
@@ -486,6 +622,47 @@ mod tests {
     }
 
     #[test]
+    fn express_extraction_keeps_multiline_middleware_and_path_param() {
+        let file = SourceFile {
+            path: "src/routes/invoices.ts".into(),
+            relative_path: "src/routes/invoices.ts".to_owned(),
+            language: Language::TypeScript,
+            text: String::new(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![CallFact {
+                callee: "router.patch".to_owned(),
+                arguments: vec![
+                    "\"/clients/:clientId/invoices/:invoiceId\"".to_owned(),
+                    "requireAuth".to_owned(),
+                    "requirePermission(\"invoice:update\")".to_owned(),
+                    "async (req, res) => {\n await updateInvoice(req.params.invoiceId, req.body)\n}"
+                        .to_owned(),
+                ],
+                span: SourceSpan::single_line("src/routes/invoices.ts", 10),
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let facts = extract_express(&file, &parsed, 0);
+        assert_eq!(
+            facts.routes[0].middleware,
+            vec!["requireAuth", "requirePermission"]
+        );
+        assert_eq!(facts.routes[0].handler, "inline_handler");
+        let route_param = facts
+            .sources
+            .iter()
+            .find(|source| source.id.ends_with(":route_param"))
+            .expect("route param source should exist");
+        assert_eq!(route_param.name, "clientId");
+    }
+
+    #[test]
     fn fastapi_extraction_uses_decorator_call_and_next_symbol() {
         let file = SourceFile {
             path: "app/routes.py".into(),
@@ -512,5 +689,58 @@ mod tests {
 
         let facts = extract_fastapi(&file, &parsed, 0);
         assert_eq!(facts.routes[0].handler, "update_invoice");
+    }
+
+    #[test]
+    fn fastapi_extraction_keeps_dependencies_and_path_param() {
+        let file = SourceFile {
+            path: "app/routes.py".into(),
+            relative_path: "app/routes.py".to_owned(),
+            language: Language::Python,
+            text: "@router.patch(\"/invoices/{invoice_id}\", dependencies=[Depends(require_permission(\"invoice:update\"))])\ndef update_invoice(invoice_id: str, body: dict, current_user=Depends(get_current_user)):\n    pass\n".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::Python,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: vec![SymbolFact {
+                name: "update_invoice".to_owned(),
+                kind: SymbolKind::Function,
+                span: SourceSpan::single_line("app/routes.py", 2),
+            }],
+            calls: vec![
+                CallFact {
+                    callee: "router.patch".to_owned(),
+                    arguments: vec![
+                        "\"/invoices/{invoice_id}\"".to_owned(),
+                        "dependencies=[Depends(require_permission(\"invoice:update\"))]".to_owned(),
+                    ],
+                    span: SourceSpan::single_line("app/routes.py", 1),
+                },
+                CallFact {
+                    callee: "Depends".to_owned(),
+                    arguments: vec!["require_permission(\"invoice:update\")".to_owned()],
+                    span: SourceSpan::single_line("app/routes.py", 1),
+                },
+                CallFact {
+                    callee: "Depends".to_owned(),
+                    arguments: vec!["get_current_user".to_owned()],
+                    span: SourceSpan::single_line("app/routes.py", 2),
+                },
+            ],
+            suppressions: Vec::new(),
+        };
+
+        let facts = extract_fastapi(&file, &parsed, 0);
+        assert_eq!(
+            facts.routes[0].middleware,
+            vec!["get_current_user", "require_permission"]
+        );
+        let route_param = facts
+            .sources
+            .iter()
+            .find(|source| source.id.ends_with(":route_param"))
+            .expect("route param source should exist");
+        assert_eq!(route_param.name, "invoice_id");
     }
 }

--- a/crates/rulepath_orms/src/lib.rs
+++ b/crates/rulepath_orms/src/lib.rs
@@ -130,11 +130,15 @@ fn extract_prisma_operations(
     config: &ResolvedConfig,
 ) -> Vec<OperationFact> {
     let mut operations = Vec::new();
+    let client_names = prisma_client_names(file);
     for call in &parsed.calls {
-        let Some(rest) = call.callee.strip_prefix("prisma.") else {
+        let mut parts = call.callee.split('.');
+        let Some(client) = parts.next() else {
             continue;
         };
-        let mut parts = rest.split('.');
+        if !client_names.iter().any(|name| name == client) {
+            continue;
+        };
         let Some(model) = parts.next() else {
             continue;
         };
@@ -155,8 +159,14 @@ fn extract_prisma_operations(
             resource: resource.clone(),
             operation,
             method: format!("prisma.{model}.{method}"),
-            filters: extract_filters(&resource, &window, config, file),
-            mutation_fields: extract_mutation_fields(&window, file),
+            filters: extract_prisma_filters(
+                &resource,
+                &call.arguments.join(", "),
+                &window,
+                config,
+                file,
+            ),
+            mutation_fields: extract_prisma_mutation_fields(&call.arguments.join(", "), file),
             bulk: matches!(
                 operation,
                 OperationType::BulkUpdate | OperationType::BulkDelete
@@ -165,6 +175,68 @@ fn extract_prisma_operations(
         });
     }
     operations
+}
+
+fn prisma_client_names(file: &SourceFile) -> Vec<String> {
+    let mut names = vec!["prisma".to_owned()];
+    for line in file.text.lines() {
+        let trimmed = line.trim();
+        if !trimmed.contains("PrismaClient") {
+            continue;
+        }
+        if let Some(rest) = trimmed
+            .strip_prefix("const ")
+            .or_else(|| trimmed.strip_prefix("let "))
+            .or_else(|| trimmed.strip_prefix("var "))
+        {
+            if let Some(name) = rest
+                .split('=')
+                .next()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+            {
+                names.push(name.to_owned());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn extract_prisma_filters(
+    resource: &str,
+    arguments: &str,
+    window: &str,
+    config: &ResolvedConfig,
+    file: &SourceFile,
+) -> Vec<FilterFact> {
+    let where_section = object_section(arguments, "where").unwrap_or(arguments);
+    let mut filters = Vec::new();
+    if contains_id_filter(where_section) {
+        filters.push(FilterFact {
+            field: "id".to_owned(),
+            value: request_controlled_value(where_section),
+            source_id: Some(format!("source:{}:route_param", file.relative_path)),
+        });
+    }
+    for field in config.tenant_fields_for(resource) {
+        if where_section.contains(&field) || window.contains(&field) {
+            filters.push(FilterFact {
+                field,
+                value: "current principal scope".to_owned(),
+                source_id: None,
+            });
+        }
+    }
+    filters
+}
+
+fn extract_prisma_mutation_fields(arguments: &str, file: &SourceFile) -> Vec<MutationFieldFact> {
+    let Some(data_section) = object_section(arguments, "data") else {
+        return Vec::new();
+    };
+    extract_mutation_fields(data_section, file)
 }
 
 fn extract_sqlalchemy_operations(
@@ -286,7 +358,13 @@ fn extract_filters(
 
 fn extract_mutation_fields(window: &str, file: &SourceFile) -> Vec<MutationFieldFact> {
     let mut fields = Vec::new();
-    if window.contains("data: body")
+    let trimmed = window
+        .trim()
+        .trim_matches(|character| character == '{' || character == '}');
+    if matches!(
+        trimmed,
+        "body" | "req.body" | "request.body" | "request.data"
+    ) || window.contains("data: body")
         || window.contains("data: req.body")
         || window.contains("data: request.body")
         || window.contains("request.data")
@@ -317,6 +395,47 @@ fn extract_mutation_fields(window: &str, file: &SourceFile) -> Vec<MutationField
         }
     }
     fields
+}
+
+fn object_section<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+    let key_index = text.find(key)?;
+    let after_key = &text[key_index + key.len()..];
+    let colon = after_key.find(':')?;
+    let after_colon = after_key[colon + 1..].trim_start();
+    let open = after_colon.chars().next()?;
+    if open != '{' {
+        return Some(after_colon.split(',').next().unwrap_or(after_colon).trim());
+    }
+    let mut depth = 0usize;
+    for (index, character) in after_colon.char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(&after_colon[..=index]);
+                }
+            }
+            _ => {}
+        }
+    }
+    Some(after_colon)
+}
+
+fn request_controlled_value(text: &str) -> String {
+    for candidate in [
+        "req.params",
+        "params",
+        "invoice_id",
+        "client_id",
+        "id",
+        "request.path_params",
+    ] {
+        if text.contains(candidate) {
+            return candidate.to_owned();
+        }
+    }
+    "request-controlled id".to_owned()
 }
 
 fn contains_id_filter(window: &str) -> bool {
@@ -439,5 +558,76 @@ mod tests {
         let operations = extract_prisma_operations(&file, &parsed, &empty_config());
         assert_eq!(operations[0].resource, "Invoice");
         assert_eq!(operations[0].operation, OperationType::Update);
+    }
+
+    #[test]
+    fn prisma_extraction_handles_alias_nested_where_and_data_without_select_noise() {
+        let file = SourceFile {
+            path: "src/services/invoices.ts".into(),
+            relative_path: "src/services/invoices.ts".to_owned(),
+            language: Language::TypeScript,
+            text: "const db = new PrismaClient()\nreturn db.invoice.update({ where: { id: req.params.invoiceId, tenantId: req.user.tenantId }, data: { status: req.body.status }, select: { id: true } })".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![CallFact {
+                callee: "db.invoice.update".to_owned(),
+                arguments: vec![
+                    "{ where: { id: req.params.invoiceId, tenantId: req.user.tenantId }, data: { status: req.body.status }, select: { id: true } }".to_owned(),
+                ],
+                span: SourceSpan::single_line("src/services/invoices.ts", 2),
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_prisma_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].method, "prisma.invoice.update");
+        assert!(operations[0]
+            .filters
+            .iter()
+            .any(|filter| filter.field == "id" && filter.value == "req.params"));
+        assert!(operations[0]
+            .filters
+            .iter()
+            .any(|filter| filter.field == "tenantId"));
+        assert_eq!(operations[0].mutation_fields[0].field, "status");
+    }
+
+    #[test]
+    fn prisma_extraction_marks_bulk_operations() {
+        let file = SourceFile {
+            path: "src/services/invoices.ts".into(),
+            relative_path: "src/services/invoices.ts".to_owned(),
+            language: Language::TypeScript,
+            text: String::new(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![
+                CallFact {
+                    callee: "prisma.invoice.updateMany".to_owned(),
+                    arguments: vec!["{ where: { clientId }, data: req.body }".to_owned()],
+                    span: SourceSpan::single_line("src/services/invoices.ts", 3),
+                },
+                CallFact {
+                    callee: "prisma.invoice.deleteMany".to_owned(),
+                    arguments: vec!["{ where: { clientId } }".to_owned()],
+                    span: SourceSpan::single_line("src/services/invoices.ts", 4),
+                },
+            ],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_prisma_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].operation, OperationType::BulkUpdate);
+        assert!(operations[0].bulk);
+        assert_eq!(operations[1].operation, OperationType::BulkDelete);
+        assert!(operations[1].bulk);
     }
 }

--- a/crates/rulepath_orms/src/lib.rs
+++ b/crates/rulepath_orms/src/lib.rs
@@ -246,45 +246,145 @@ fn extract_sqlalchemy_operations(
 ) -> Vec<OperationFact> {
     let mut operations = Vec::new();
     for call in &parsed.calls {
-        let marker = call.callee.as_str();
-        if !matches!(marker, "session.get" | "select" | "update" | "delete") {
-            continue;
-        }
-        let Some(resource) = call
-            .arguments
-            .first()
-            .map(|argument| argument.trim())
-            .filter(|argument| !argument.is_empty())
-        else {
+        let Some((resource, method, operation_hint)) = sqlalchemy_call_shape(call) else {
             continue;
         };
         let window = surrounding_window_for_line(&file.text, call.span.start.line, 500);
-        let operation = if marker == "delete" {
-            OperationType::Delete
-        } else if marker == "update"
-            || window.contains("session.commit")
-            || window.contains("body.status")
+        let operation = if operation_hint == OperationType::Read
+            && window.contains("session.commit")
+            && contains_body_assignment(&window)
         {
             OperationType::Update
         } else {
-            OperationType::Read
+            operation_hint
         };
         operations.push(OperationFact {
             id: format!(
-                "sink:sqlalchemy.{resource}.{marker}:{}:{}",
+                "sink:sqlalchemy.{resource}.{method}:{}:{}",
                 file.relative_path, call.span.start.line
             ),
             data_layer: DataLayer::SqlAlchemy,
-            resource: resource.to_owned(),
+            resource: resource.clone(),
             operation,
-            method: marker.to_owned(),
-            filters: extract_filters(resource, &window, config, file),
+            method,
+            filters: extract_sqlalchemy_filters(&resource, &call.arguments, &window, config, file),
             mutation_fields: extract_mutation_fields(&window, file),
-            bulk: marker == "update" || marker == "delete",
+            bulk: matches!(
+                operation,
+                OperationType::BulkUpdate | OperationType::BulkDelete
+            ),
             span: call.span.clone(),
         });
     }
     operations
+}
+
+fn sqlalchemy_call_shape(
+    call: &rulepath_parsers::CallFact,
+) -> Option<(String, String, OperationType)> {
+    match call.callee.as_str() {
+        "session.get" => call.arguments.first().map(|resource| {
+            (
+                resource.trim().to_owned(),
+                "session.get".to_owned(),
+                OperationType::Read,
+            )
+        }),
+        "select" => call.arguments.first().map(|resource| {
+            (
+                resource.trim().to_owned(),
+                "select".to_owned(),
+                OperationType::Read,
+            )
+        }),
+        "update" => call.arguments.first().map(|resource| {
+            (
+                resource.trim().to_owned(),
+                "update".to_owned(),
+                OperationType::BulkUpdate,
+            )
+        }),
+        "delete" => call.arguments.first().map(|resource| {
+            (
+                resource.trim().to_owned(),
+                "delete".to_owned(),
+                OperationType::BulkDelete,
+            )
+        }),
+        "session.execute" => call
+            .arguments
+            .first()
+            .and_then(|argument| sqlalchemy_execute_shape(argument)),
+        _ => None,
+    }
+}
+
+fn sqlalchemy_execute_shape(argument: &str) -> Option<(String, String, OperationType)> {
+    for (prefix, operation) in [
+        ("select(", OperationType::Read),
+        ("update(", OperationType::BulkUpdate),
+        ("delete(", OperationType::BulkDelete),
+    ] {
+        if let Some(rest) = argument.trim().strip_prefix(prefix) {
+            let resource = rest.split([')', ',', '.']).next()?.trim();
+            if !resource.is_empty() {
+                return Some((
+                    resource.to_owned(),
+                    prefix.trim_end_matches('(').to_owned(),
+                    operation,
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn extract_sqlalchemy_filters(
+    resource: &str,
+    arguments: &[String],
+    window: &str,
+    config: &ResolvedConfig,
+    file: &SourceFile,
+) -> Vec<FilterFact> {
+    let mut filters = Vec::new();
+    if arguments
+        .get(1)
+        .is_some_and(|argument| is_request_controlled_id_expression(argument))
+        || contains_id_filter(window)
+    {
+        filters.push(FilterFact {
+            field: "id".to_owned(),
+            value: arguments
+                .get(1)
+                .cloned()
+                .unwrap_or_else(|| request_controlled_value(window)),
+            source_id: Some(format!("source:{}:route_param", file.relative_path)),
+        });
+    }
+    for field in config.tenant_fields_for(resource) {
+        if window.contains(&field) {
+            filters.push(FilterFact {
+                field,
+                value: "current principal scope".to_owned(),
+                source_id: None,
+            });
+        }
+    }
+    filters
+}
+
+fn is_request_controlled_id_expression(argument: &str) -> bool {
+    let trimmed = argument.trim();
+    trimmed == "id"
+        || trimmed.ends_with("_id")
+        || trimmed.ends_with("Id")
+        || trimmed.contains("params")
+}
+
+fn contains_body_assignment(window: &str) -> bool {
+    window
+        .lines()
+        .any(|line| line.contains(" = body.") || line.contains(" = request.data"))
 }
 
 fn extract_django_orm_operations(file: &SourceFile, config: &ResolvedConfig) -> Vec<OperationFact> {
@@ -394,6 +494,37 @@ fn extract_mutation_fields(window: &str, file: &SourceFile) -> Vec<MutationField
             });
         }
     }
+    for field in assignment_mutation_fields(window) {
+        if !fields.iter().any(|existing| existing.field == field) {
+            fields.push(MutationFieldFact {
+                field: field.clone(),
+                value: format!("body.{field}"),
+                source_id: Some(format!("source:{}:body", file.relative_path)),
+            });
+        }
+    }
+    fields
+}
+
+fn assignment_mutation_fields(window: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    for line in window.lines() {
+        let trimmed = line.trim();
+        if !(trimmed.contains(" = body.") || trimmed.contains(" = request.data")) {
+            continue;
+        }
+        let Some(left) = trimmed.split('=').next().map(str::trim) else {
+            continue;
+        };
+        let Some(field) = left.rsplit('.').next() else {
+            continue;
+        };
+        if !field.is_empty() {
+            fields.push(field.to_owned());
+        }
+    }
+    fields.sort();
+    fields.dedup();
     fields
 }
 
@@ -625,6 +756,75 @@ mod tests {
         };
 
         let operations = extract_prisma_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].operation, OperationType::BulkUpdate);
+        assert!(operations[0].bulk);
+        assert_eq!(operations[1].operation, OperationType::BulkDelete);
+        assert!(operations[1].bulk);
+    }
+
+    #[test]
+    fn sqlalchemy_session_get_and_object_assignment_becomes_update() {
+        let file = SourceFile {
+            path: "app/invoice_service.py".into(),
+            relative_path: "app/invoice_service.py".to_owned(),
+            language: Language::Python,
+            text: "def update_invoice(invoice_id, body):\n    invoice = session.get(Invoice, invoice_id)\n    invoice.status = body.status\n    session.commit()\n".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::Python,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![CallFact {
+                callee: "session.get".to_owned(),
+                arguments: vec!["Invoice".to_owned(), "invoice_id".to_owned()],
+                span: SourceSpan::single_line("app/invoice_service.py", 2),
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_sqlalchemy_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].operation, OperationType::Update);
+        assert!(operations[0]
+            .filters
+            .iter()
+            .any(|filter| filter.field == "id" && filter.value == "invoice_id"));
+        assert_eq!(operations[0].mutation_fields[0].field, "status");
+    }
+
+    #[test]
+    fn sqlalchemy_core_bulk_operations_are_marked() {
+        let file = SourceFile {
+            path: "app/invoice_service.py".into(),
+            relative_path: "app/invoice_service.py".to_owned(),
+            language: Language::Python,
+            text: "session.execute(update(Invoice).where(Invoice.client_id == client_id).values(status=body.status))\nsession.execute(delete(Invoice).where(Invoice.client_id == client_id))".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::Python,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![
+                CallFact {
+                    callee: "session.execute".to_owned(),
+                    arguments: vec![
+                        "update(Invoice).where(Invoice.client_id == client_id).values(status=body.status)"
+                            .to_owned(),
+                    ],
+                    span: SourceSpan::single_line("app/invoice_service.py", 1),
+                },
+                CallFact {
+                    callee: "session.execute".to_owned(),
+                    arguments: vec!["delete(Invoice).where(Invoice.client_id == client_id)"
+                        .to_owned()],
+                    span: SourceSpan::single_line("app/invoice_service.py", 2),
+                },
+            ],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_sqlalchemy_operations(&file, &parsed, &empty_config());
         assert_eq!(operations[0].operation, OperationType::BulkUpdate);
         assert!(operations[0].bulk);
         assert_eq!(operations[1].operation, OperationType::BulkDelete);

--- a/crates/rulepath_reporters/src/lib.rs
+++ b/crates/rulepath_reporters/src/lib.rs
@@ -87,7 +87,9 @@ fn render_diagnostic_detail(diagnostic: &Diagnostic) -> String {
         for frame in &diagnostic.call_path {
             output.push_str(&format!(
                 "  {}:{} {}()\n",
-                frame.file, frame.line, frame.function
+                normalized_path(&frame.file),
+                frame.line,
+                frame.function
             ));
         }
     } else if let Some(call_path_id) = &diagnostic.call_path_id {
@@ -121,6 +123,10 @@ fn render_diagnostic_detail(diagnostic: &Diagnostic) -> String {
         output.push_str(&format!("\nSuggested fix:\n  {fix}\n"));
     }
     output
+}
+
+fn normalized_path(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 fn severity_label(severity: Severity) -> &'static str {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,4 +60,4 @@ Normal scans must stay Rust-native. Optional sidecars may be added later only fo
 13. Apply baseline and CI policy.
 14. Emit reports.
 
-Framework and data-layer extraction is registered by adapter descriptors, so scan orchestration does not need framework-specific or ORM-specific lexical logic. `rulepath_dataflow` owns the scan context, route-to-operation source propagation, and deterministic IR assembly.
+Framework and data-layer extraction is registered by adapter descriptors, so scan orchestration does not need framework-specific or ORM-specific lexical logic. Framework adapters own route, handler, middleware/dependency, and request-source facts. `rulepath_dataflow` owns the scan context, route-to-operation source propagation, and deterministic IR assembly.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -47,4 +47,6 @@ Uncertainty should reduce confidence or produce review hints.
 
 The current analyzer builds a conservative trace index from parser-backed symbols and calls. Framework and data-layer adapters consume those parsed facts through deterministic registries, then dataflow connects route request sources to operations when parsed calls cross from route handlers into service functions.
 
+Prisma extraction is parser-call backed and recognizes configured client aliases, supported CRUD and bulk methods, nested `where` filters, and `data` mutation payloads while ignoring projection-only `select` and `include` arguments.
+
 The trace remains intentionally narrow and fixture-backed. Unsupported dynamic dispatch, generated code, or framework behavior should reduce confidence or produce review hints rather than inventing unsupported edges.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -53,4 +53,4 @@ SQLAlchemy extraction is parser-call backed for `session.get`, `select`, `update
 
 Auth, authorization, scope, transaction, invariant, and idempotency evidence is normalized in `rulepath_auth`. Evidence classification is driven by resolved config where possible, with route middleware/dependencies and direct helper calls associated back to the nearest route or sink during IR assembly.
 
-The trace remains intentionally narrow and fixture-backed. Unsupported dynamic dispatch, generated code, or framework behavior should reduce confidence or produce review hints rather than inventing unsupported edges.
+The trace remains intentionally narrow and fixture-backed, but it is import- and symbol-aware for simple local and relative imports. Route-to-service tracing respects `analysis.service_layer_tracing` and `analysis.max_call_depth`; unresolved or ambiguous paths should stay out of high-confidence findings rather than inheriting the first available route.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -51,4 +51,6 @@ Prisma extraction is parser-call backed and recognizes configured client aliases
 
 SQLAlchemy extraction is parser-call backed for `session.get`, `select`, `update`, `delete`, and `session.execute(...)` wrappers. Object assignment followed by `session.commit()` is modeled as a mutation so request-body field flows are visible to rules.
 
+Auth, authorization, scope, transaction, invariant, and idempotency evidence is normalized in `rulepath_auth`. Evidence classification is driven by resolved config where possible, with route middleware/dependencies and direct helper calls associated back to the nearest route or sink during IR assembly.
+
 The trace remains intentionally narrow and fixture-backed. Unsupported dynamic dispatch, generated code, or framework behavior should reduce confidence or produce review hints rather than inventing unsupported edges.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -49,4 +49,6 @@ The current analyzer builds a conservative trace index from parser-backed symbol
 
 Prisma extraction is parser-call backed and recognizes configured client aliases, supported CRUD and bulk methods, nested `where` filters, and `data` mutation payloads while ignoring projection-only `select` and `include` arguments.
 
+SQLAlchemy extraction is parser-call backed for `session.get`, `select`, `update`, `delete`, and `session.execute(...)` wrappers. Object assignment followed by `session.commit()` is modeled as a mutation so request-body field flows are visible to rules.
+
 The trace remains intentionally narrow and fixture-backed. Unsupported dynamic dispatch, generated code, or framework behavior should reduce confidence or produce review hints rather than inventing unsupported edges.


### PR DESCRIPTION
## Summary

Implements the full `phase:2-existing-wedge` issue set on one branch, with each issue handled in its own implementation commit plus a repo-level documentation/changelog commit.

- **#5 Framework adapters**: moves Express and FastAPI route extraction into `rulepath_frameworks`, including parsed handler names, middleware/dependencies, route path parameters, body sources, and multi-line route/decorator coverage.
- **#8 Prisma sinks**: expands parser-backed Prisma extraction for client aliases, CRUD and bulk methods, nested `where` filters, `data` mutation payloads, tenant fields, and projection-noise avoidance.
- **#9 SQLAlchemy sinks**: expands parser-backed SQLAlchemy extraction for `session.get`, Core `select/update/delete`, `session.execute(...)`, object assignment followed by commit, request-controlled IDs, mutation fields, and bulk operations.
- **#11 Evidence normalization**: moves config-driven auth/authorization/scope/transaction/invariant/idempotency normalization into `rulepath_auth`, including route middleware/dependency evidence and JSON observed-evidence coverage.
- **#12 Call graph tracing**: replaces one-hop service tracing with import- and symbol-aware call graph tracing, including relative imports, two-hop paths, max-depth enforcement, tracing disable behavior, and SARIF/text-ready call frames.

Fixes #5.
Fixes #8.
Fixes #9.
Fixes #11.
Fixes #12.

## Documentation

- Updated `CHANGELOG.md` with the phase 1 and phase 2 analysis changes.
- Updated `README.md` with the parser-backed analysis model.
- Updated architecture and implementation notes to describe framework/data-layer adapter ownership, evidence normalization, parser-backed sink extraction, and import-aware tracing.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets`
- `cargo test --locked --workspace`