### PR TITLE
Implement Django ORM sink extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ All notable changes to Rulepath will be documented here.
 - Add parser-backed TypeScript and Python facts for imports, symbols, calls, spans, and suppressions.
 - Move Express and FastAPI route extraction into framework adapters with middleware, dependency, handler, and request-source facts.
 - Move Prisma and SQLAlchemy sink extraction into data-layer adapters with parser-backed operations, filters, mutation fields, and bulk operation detection.
+- Add Django ORM sink extraction for model manager calls, queryset mutations, serializer saves, request-controlled filters, tenant scope filters, and request-body mutation fields.
 - Normalize configured authentication, authorization, scope, transaction, invariant, and idempotency evidence through `rulepath_auth`.
 - Replace one-hop service tracing with an import- and symbol-aware call graph that respects `analysis.service_layer_tracing` and `analysis.max_call_depth`.

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -83,6 +83,21 @@ fn fastapi_sqlalchemy_unsafe_emits_python_parity_findings() {
 }
 
 #[test]
+fn django_drf_unsafe_emits_unscoped_access_finding() {
+    let path = fixture_path("fixtures/django_drf/unsafe");
+    let stdout = run_rulepath(&["scan", path.to_str().expect("utf-8 fixture path")]);
+    assert!(stdout.contains("INV001"));
+    assert!(stdout.contains("Unscoped Invoice access"));
+}
+
+#[test]
+fn django_drf_safe_is_clean() {
+    let path = fixture_path("fixtures/django_drf/safe");
+    let stdout = run_rulepath(&["scan", path.to_str().expect("utf-8 fixture path")]);
+    assert!(stdout.contains("Findings: 0"));
+}
+
+#[test]
 fn traced_service_sink_uses_route_request_sources() {
     let path = fixture_path("fixtures/express_prisma/unsafe");
     let stdout = run_rulepath(&[

--- a/crates/rulepath_frameworks/src/lib.rs
+++ b/crates/rulepath_frameworks/src/lib.rs
@@ -284,8 +284,12 @@ fn extract_django_rest_framework(file: &SourceFile, route_offset: usize) -> Fram
         return FrameworkFacts::default();
     }
     let mut facts = FrameworkFacts::default();
-    for (line_index, line) in file.text.lines().enumerate() {
-        if line.contains("ModelViewSet") || line.contains("APIView") {
+    let lines = file.text.lines().collect::<Vec<_>>();
+    for (line_index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("class ")
+            && (trimmed.contains("ModelViewSet") || trimmed.contains("APIView"))
+        {
             push_route(
                 file,
                 &mut facts,
@@ -293,7 +297,7 @@ fn extract_django_rest_framework(file: &SourceFile, route_offset: usize) -> Fram
                 "GET".to_owned(),
                 inferred_django_path(file),
                 class_name_from_line(line).unwrap_or_else(|| "drf_view".to_owned()),
-                django_permission_classes(line),
+                django_permission_classes(&lines, line_index),
                 SourceSpan::single_line(file.relative_path.as_str(), line_index + 1),
                 route_offset,
             );
@@ -468,12 +472,32 @@ fn route_param_name(framework: Framework, path: &str) -> Option<String> {
     }
 }
 
-fn django_permission_classes(line: &str) -> Vec<String> {
-    if line.contains("permission_classes") {
-        vec!["permission_classes".to_owned()]
-    } else {
-        Vec::new()
+fn django_permission_classes(lines: &[&str], class_line_index: usize) -> Vec<String> {
+    let mut classes = Vec::new();
+    for line in lines.iter().skip(class_line_index + 1) {
+        let trimmed = line.trim();
+        if trimmed.starts_with("class ") {
+            break;
+        }
+        if !trimmed.starts_with("permission_classes") {
+            continue;
+        }
+        let Some(open) = trimmed.find('[') else {
+            continue;
+        };
+        let Some(close) = trimmed[open + 1..].find(']') else {
+            continue;
+        };
+        classes.extend(
+            trimmed[open + 1..open + 1 + close]
+                .split(',')
+                .filter_map(|item| {
+                    let name = item.trim();
+                    (!name.is_empty()).then(|| name.to_owned())
+                }),
+        );
     }
+    classes
 }
 
 fn express_method(callee: &str) -> Option<&'static str> {
@@ -742,5 +766,24 @@ mod tests {
             .find(|source| source.id.ends_with(":route_param"))
             .expect("route param source should exist");
         assert_eq!(route_param.name, "invoice_id");
+    }
+
+    #[test]
+    fn drf_extraction_uses_class_span_and_permission_classes() {
+        let file = SourceFile {
+            path: "app/views.py".into(),
+            relative_path: "app/views.py".to_owned(),
+            language: Language::Python,
+            text: "from rest_framework.viewsets import ModelViewSet\n\nclass InvoiceViewSet(ModelViewSet):\n    permission_classes = [IsAuthenticated, InvoicePermission]\n"
+                .to_owned(),
+        };
+
+        let facts = extract_django_rest_framework(&file, 0);
+        assert_eq!(facts.routes[0].handler, "InvoiceViewSet");
+        assert_eq!(facts.routes[0].span.start.line, 3);
+        assert_eq!(
+            facts.routes[0].middleware,
+            vec!["IsAuthenticated", "InvoicePermission"]
+        );
     }
 }

--- a/crates/rulepath_orms/src/lib.rs
+++ b/crates/rulepath_orms/src/lib.rs
@@ -40,7 +40,7 @@ impl DataLayerAdapter for BuiltInDataLayerAdapter {
         match self.descriptor.id {
             DataLayer::Prisma => extract_prisma_operations(file, parsed, config),
             DataLayer::SqlAlchemy => extract_sqlalchemy_operations(file, parsed, config),
-            DataLayer::DjangoOrm => extract_django_orm_operations(file, config),
+            DataLayer::DjangoOrm => extract_django_orm_operations(file, parsed, config),
             DataLayer::Unknown => Vec::new(),
         }
     }
@@ -387,8 +387,61 @@ fn contains_body_assignment(window: &str) -> bool {
         .any(|line| line.contains(" = body.") || line.contains(" = request.data"))
 }
 
-fn extract_django_orm_operations(file: &SourceFile, config: &ResolvedConfig) -> Vec<OperationFact> {
+fn extract_django_orm_operations(
+    file: &SourceFile,
+    parsed: &ParsedFile,
+    config: &ResolvedConfig,
+) -> Vec<OperationFact> {
     let mut operations = Vec::new();
+    for call in &parsed.calls {
+        if let Some(shape) = django_call_shape(call.callee.as_str()) {
+            let window = surrounding_window_for_line(&file.text, call.span.start.line, 500);
+            operations.push(OperationFact {
+                id: format!(
+                    "sink:django_orm.{}.{}:{}:{}",
+                    shape.resource, shape.method, file.relative_path, call.span.start.line
+                ),
+                data_layer: DataLayer::DjangoOrm,
+                resource: shape.resource.clone(),
+                operation: shape.operation,
+                method: shape.method,
+                filters: extract_django_filters(
+                    &shape.resource,
+                    &call.arguments.join(", "),
+                    call.callee.as_str(),
+                    &window,
+                    config,
+                    file,
+                ),
+                mutation_fields: extract_django_mutation_fields(
+                    &call.arguments.join(", "),
+                    &window,
+                    file,
+                ),
+                bulk: matches!(
+                    shape.operation,
+                    OperationType::BulkUpdate | OperationType::BulkDelete
+                ),
+                span: call.span.clone(),
+            });
+        } else if let Some(shape) = django_save_shape(call.callee.as_str(), &file.text) {
+            let window = surrounding_window_for_line(&file.text, call.span.start.line, 500);
+            operations.push(OperationFact {
+                id: format!(
+                    "sink:django_orm.{}.{}:{}:{}",
+                    shape.resource, shape.method, file.relative_path, call.span.start.line
+                ),
+                data_layer: DataLayer::DjangoOrm,
+                resource: shape.resource.clone(),
+                operation: shape.operation,
+                method: shape.method,
+                filters: extract_filters(&shape.resource, &window, config, file),
+                mutation_fields: extract_django_mutation_fields("", &window, file),
+                bulk: false,
+                span: call.span.clone(),
+            });
+        }
+    }
     for (offset, _) in file.text.match_indices(".objects.") {
         let before = &file.text[..offset];
         let resource = before
@@ -408,6 +461,12 @@ fn extract_django_orm_operations(file: &SourceFile, config: &ResolvedConfig) -> 
             continue;
         };
         let line = rulepath_workspace::line_number_for_offset(&file.text, offset);
+        if operations
+            .iter()
+            .any(|operation| operation.span.start.line == line && operation.resource == resource)
+        {
+            continue;
+        }
         let window = surrounding_window_for_offset(&file.text, offset, 500);
         operations.push(OperationFact {
             id: format!(
@@ -427,7 +486,145 @@ fn extract_django_orm_operations(file: &SourceFile, config: &ResolvedConfig) -> 
             span: SourceSpan::single_line(file.relative_path.as_str(), line),
         });
     }
+    operations.sort_by(|left, right| {
+        left.span
+            .start
+            .line
+            .cmp(&right.span.start.line)
+            .then(left.id.cmp(&right.id))
+    });
+    operations.dedup_by(|left, right| left.id == right.id);
     operations
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DjangoOperationShape {
+    resource: String,
+    method: String,
+    operation: OperationType,
+}
+
+fn django_call_shape(callee: &str) -> Option<DjangoOperationShape> {
+    let objects_index = callee.find(".objects.")?;
+    let resource = callee[..objects_index]
+        .rsplit('.')
+        .next()
+        .unwrap_or_default()
+        .to_owned();
+    if resource.is_empty() {
+        return None;
+    }
+    let after_objects = &callee[objects_index + ".objects.".len()..];
+    let method = django_method_from_chain(after_objects)?;
+    let operation = django_operation(method)?;
+    let method = format!("{resource}.objects.{method}");
+    Some(DjangoOperationShape {
+        resource,
+        method,
+        operation,
+    })
+}
+
+fn django_method_from_chain(chain: &str) -> Option<&'static str> {
+    for method in ["update", "delete"] {
+        if chain.starts_with(method) || chain.contains(&format!(".{method}")) {
+            return Some(method);
+        }
+    }
+    ["get", "filter", "all", "create"]
+        .into_iter()
+        .find(|&method| chain.starts_with(method))
+}
+
+fn django_save_shape(callee: &str, text: &str) -> Option<DjangoOperationShape> {
+    if !callee.ends_with(".save") && callee != "save" {
+        return None;
+    }
+    let resource = serializer_resource(text).or_else(|| infer_resource_from_text(text))?;
+    let operation = if text.contains("instance=") || text.contains(".objects.get") {
+        OperationType::Update
+    } else {
+        OperationType::Create
+    };
+    Some(DjangoOperationShape {
+        resource,
+        method: callee.to_owned(),
+        operation,
+    })
+}
+
+fn serializer_resource(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let Some(index) = line.find("Serializer") else {
+            continue;
+        };
+        let before = &line[..index];
+        let name = before
+            .rsplit(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+            .find(|part| !part.is_empty())?;
+        if !name.is_empty() {
+            return Some(name.to_owned());
+        }
+    }
+    None
+}
+
+fn extract_django_filters(
+    resource: &str,
+    arguments: &str,
+    callee: &str,
+    window: &str,
+    config: &ResolvedConfig,
+    file: &SourceFile,
+) -> Vec<FilterFact> {
+    let filter_text = format!("{arguments}\n{callee}\n{window}");
+    let mut filters = Vec::new();
+    if contains_id_filter(filter_text.as_str())
+        || filter_text.contains("kwargs")
+        || filter_text.contains("\"pk\"")
+        || filter_text.contains("'pk'")
+        || filter_text.contains("query_params")
+    {
+        filters.push(FilterFact {
+            field: "id".to_owned(),
+            value: request_controlled_value(filter_text.as_str()),
+            source_id: Some(format!("source:{}:route_param", file.relative_path)),
+        });
+    }
+    for field in config.tenant_fields_for(resource) {
+        if filter_text.contains(&field) {
+            filters.push(FilterFact {
+                field,
+                value: "current principal scope".to_owned(),
+                source_id: None,
+            });
+        }
+    }
+    filters.sort_by(|left, right| left.field.cmp(&right.field));
+    filters.dedup_by(|left, right| left.field == right.field && left.source_id == right.source_id);
+    filters
+}
+
+fn extract_django_mutation_fields(
+    arguments: &str,
+    window: &str,
+    file: &SourceFile,
+) -> Vec<MutationFieldFact> {
+    let text = format!("{arguments}\n{window}");
+    let mut fields = extract_mutation_fields(text.as_str(), file);
+    if text.contains("serializer")
+        && (text.contains("request.data") || text.contains("validated_data"))
+        && fields.is_empty()
+    {
+        fields.push(MutationFieldFact {
+            field: "*".to_owned(),
+            value: "serializer input".to_owned(),
+            source_id: Some(format!("source:{}:body", file.relative_path)),
+        });
+    }
+    fields.sort_by(|left, right| left.field.cmp(&right.field));
+    fields.dedup_by(|left, right| left.field == right.field && left.source_id == right.source_id);
+    fields
 }
 
 fn extract_filters(
@@ -829,5 +1026,124 @@ mod tests {
         assert!(operations[0].bulk);
         assert_eq!(operations[1].operation, OperationType::BulkDelete);
         assert!(operations[1].bulk);
+    }
+
+    #[test]
+    fn django_get_filter_and_tenant_scope_are_extracted() {
+        let file = SourceFile {
+            path: "app/views.py".into(),
+            relative_path: "app/views.py".to_owned(),
+            language: Language::Python,
+            text: "Invoice.objects.get(id=self.kwargs[\"pk\"])\nInvoice.objects.filter(tenant_id=self.request.user.tenant_id)\n".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::Python,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![
+                CallFact {
+                    callee: "Invoice.objects.get".to_owned(),
+                    arguments: vec!["id=self.kwargs[\"pk\"]".to_owned()],
+                    span: SourceSpan::single_line("app/views.py", 1),
+                },
+                CallFact {
+                    callee: "Invoice.objects.filter".to_owned(),
+                    arguments: vec!["tenant_id=self.request.user.tenant_id".to_owned()],
+                    span: SourceSpan::single_line("app/views.py", 2),
+                },
+            ],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_django_orm_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].operation, OperationType::Read);
+        assert!(operations[0]
+            .filters
+            .iter()
+            .any(|filter| filter.field == "id" && filter.source_id.is_some()));
+        assert!(operations[1]
+            .filters
+            .iter()
+            .any(|filter| filter.field == "tenant_id" && filter.source_id.is_none()));
+    }
+
+    #[test]
+    fn django_create_and_queryset_bulk_mutations_are_extracted() {
+        let file = SourceFile {
+            path: "app/views.py".into(),
+            relative_path: "app/views.py".to_owned(),
+            language: Language::Python,
+            text: "Invoice.objects.create(status=request.data[\"status\"])\nInvoice.objects.filter(client_id=self.kwargs[\"client_id\"]).update(status=request.data[\"status\"])\nInvoice.objects.filter(client_id=self.kwargs[\"client_id\"]).delete()\n".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::Python,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![
+                CallFact {
+                    callee: "Invoice.objects.create".to_owned(),
+                    arguments: vec!["status=request.data[\"status\"]".to_owned()],
+                    span: SourceSpan::single_line("app/views.py", 1),
+                },
+                CallFact {
+                    callee: "Invoice.objects.filter(client_id=self.kwargs[\"client_id\"]).update"
+                        .to_owned(),
+                    arguments: vec!["status=request.data[\"status\"]".to_owned()],
+                    span: SourceSpan::single_line("app/views.py", 2),
+                },
+                CallFact {
+                    callee: "Invoice.objects.filter(client_id=self.kwargs[\"client_id\"]).delete"
+                        .to_owned(),
+                    arguments: Vec::new(),
+                    span: SourceSpan::single_line("app/views.py", 3),
+                },
+            ],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_django_orm_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].operation, OperationType::Create);
+        assert!(operations[0]
+            .mutation_fields
+            .iter()
+            .any(|field| field.field == "status" && field.source_id.is_some()));
+        assert!(operations
+            .iter()
+            .any(|operation| operation.operation == OperationType::BulkUpdate && operation.bulk));
+        assert!(operations
+            .iter()
+            .any(|operation| operation.operation == OperationType::BulkDelete && operation.bulk));
+    }
+
+    #[test]
+    fn django_serializer_save_uses_request_body() {
+        let file = SourceFile {
+            path: "app/views.py".into(),
+            relative_path: "app/views.py".to_owned(),
+            language: Language::Python,
+            text: "serializer = InvoiceSerializer(data=request.data)\nserializer.is_valid()\nserializer.save()\n".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::Python,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: Vec::new(),
+            calls: vec![CallFact {
+                callee: "serializer.save".to_owned(),
+                arguments: Vec::new(),
+                span: SourceSpan::single_line("app/views.py", 3),
+            }],
+            suppressions: Vec::new(),
+        };
+
+        let operations = extract_django_orm_operations(&file, &parsed, &empty_config());
+        assert_eq!(operations[0].resource, "Invoice");
+        assert_eq!(operations[0].operation, OperationType::Create);
+        assert!(operations[0]
+            .mutation_fields
+            .iter()
+            .any(|field| field.field == "*" && field.source_id.is_some()));
     }
 }

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -51,6 +51,8 @@ Prisma extraction is parser-call backed and recognizes configured client aliases
 
 SQLAlchemy extraction is parser-call backed for `session.get`, `select`, `update`, `delete`, and `session.execute(...)` wrappers. Object assignment followed by `session.commit()` is modeled as a mutation so request-body field flows are visible to rules.
 
+Django ORM extraction is parser-call backed for model manager calls such as `Model.objects.get/filter/create`, queryset `update` and `delete` chains, and common serializer `save()` patterns. Tenant fields from resolved config count as scope filters, while `request.data`, serializer input, kwargs, and path/query parameters are normalized as request-controlled sources.
+
 Auth, authorization, scope, transaction, invariant, and idempotency evidence is normalized in `rulepath_auth`. Evidence classification is driven by resolved config where possible, with route middleware/dependencies and direct helper calls associated back to the nearest route or sink during IR assembly.
 
 The trace remains intentionally narrow and fixture-backed, but it is import- and symbol-aware for simple local and relative imports. Route-to-service tracing respects `analysis.service_layer_tracing` and `analysis.max_call_depth`; unresolved or ambiguous paths should stay out of high-confidence findings rather than inheriting the first available route.

--- a/docs/testing-fixtures.md
+++ b/docs/testing-fixtures.md
@@ -53,3 +53,5 @@ rulepath scan fixtures/express_prisma/unsafe
 It should discover an Express route, trace to a Prisma sink, detect request-controlled IDs and body data, and emit `INV001` plus `INV002`.
 
 The second milestone mirrors that behavior for FastAPI and SQLAlchemy.
+
+The Django/DRF fixture pair verifies Django ORM extraction. The unsafe fixture should emit unscoped resource access for a request-controlled object lookup, while the safe fixture should remain clean because tenant filtering or object permission evidence is recognized.


### PR DESCRIPTION
## Summary

Implements Django ORM sink extraction for Issue #10.

- Moves Django ORM extraction onto parsed call facts in `rulepath_orms`.
- Detects `Model.objects.get/filter/all/create`, queryset `update` and `delete` chains, and common serializer `save()` patterns.
- Extracts resource/model, operation type, method, filters, mutation fields, bulk flags, and spans.
- Recognizes request-controlled IDs from kwargs/path/query-style expressions and request-controlled mutation fields from `request.data` or serializer input.
- Recognizes configured tenant fields as scope filters.
- Tightens DRF route extraction to class definitions and carries `permission_classes` into route middleware so auth evidence can attach cleanly.
- Adds Django/DRF safe and unsafe CLI fixture coverage.

Fixes #10.

## Documentation

- Updated `CHANGELOG.md` with Django ORM extraction support.
- Updated implementation notes with Django ORM extraction behavior.
- Updated fixture testing docs with Django/DRF fixture expectations.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets`
- `cargo test --locked --workspace`