### PR TITLE
Implement Next.js route and Auth.js evidence support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ All notable changes to Rulepath will be documented here.
 - Move Express and FastAPI route extraction into framework adapters with middleware, dependency, handler, and request-source facts.
 - Move Prisma and SQLAlchemy sink extraction into data-layer adapters with parser-backed operations, filters, mutation fields, and bulk operation detection.
 - Add Django ORM sink extraction for model manager calls, queryset mutations, serializer saves, request-controlled filters, tenant scope filters, and request-body mutation fields.
+- Add Next.js App Router and Pages Router API route extraction with dynamic parameter normalization, request body sources, Prisma sink propagation, and Auth.js evidence labels.
 - Normalize configured authentication, authorization, scope, transaction, invariant, and idempotency evidence through `rulepath_auth`.
 - Replace one-hop service tracing with an import- and symbol-aware call graph that respects `analysis.service_layer_tracing` and `analysis.max_call_depth`.

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -98,6 +98,55 @@ fn django_drf_safe_is_clean() {
 }
 
 #[test]
+fn nextjs_prisma_authjs_unsafe_emits_route_sources_and_authjs_evidence() {
+    let path = fixture_path("fixtures/nextjs_prisma_authjs/unsafe");
+    let stdout = run_rulepath(&[
+        "scan",
+        path.to_str().expect("utf-8 fixture path"),
+        "--format",
+        "json",
+    ]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json output should parse");
+    let finding = json["findings"]
+        .as_array()
+        .expect("findings should be an array")
+        .iter()
+        .find(|finding| finding["rule_id"] == "INV001")
+        .expect("INV001 should be emitted");
+
+    assert_eq!(
+        finding["route_id"].as_str(),
+        Some("route:NextJs:PATCH:/invoices/:invoiceId:0")
+    );
+    let source_ids = finding["source_ids"]
+        .as_array()
+        .expect("source_ids should be an array")
+        .iter()
+        .map(|value| value.as_str().expect("source id should be a string"))
+        .collect::<Vec<_>>();
+    assert!(source_ids.contains(&"source:app/api/invoices/[invoiceId]/route.ts:route_param"));
+    assert!(source_ids.contains(&"source:app/api/invoices/[invoiceId]/route.ts:body"));
+    let observed = finding["observed_evidence"]
+        .as_array()
+        .expect("observed evidence should be an array")
+        .iter()
+        .map(|value| value.as_str().expect("evidence label should be a string"))
+        .collect::<Vec<_>>();
+    assert!(observed.contains(&"authentication:auth"));
+    assert_eq!(
+        finding["call_path"][0]["file"].as_str(),
+        Some("app/api/invoices/[invoiceId]/route.ts")
+    );
+}
+
+#[test]
+fn nextjs_prisma_authjs_safe_is_clean() {
+    let path = fixture_path("fixtures/nextjs_prisma_authjs/safe");
+    let stdout = run_rulepath(&["scan", path.to_str().expect("utf-8 fixture path")]);
+    assert!(stdout.contains("Findings: 0"));
+}
+
+#[test]
 fn traced_service_sink_uses_route_request_sources() {
     let path = fixture_path("fixtures/express_prisma/unsafe");
     let stdout = run_rulepath(&[

--- a/crates/rulepath_frameworks/src/lib.rs
+++ b/crates/rulepath_frameworks/src/lib.rs
@@ -252,31 +252,144 @@ fn extract_fastapi(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) 
 }
 
 fn extract_nextjs(file: &SourceFile, parsed: &ParsedFile, route_offset: usize) -> FrameworkFacts {
-    if file.language != Language::TypeScript
-        || (!file.relative_path.contains("app/api/") && !file.relative_path.contains("pages/api/"))
-    {
+    if file.language != Language::TypeScript {
         return FrameworkFacts::default();
     }
     let mut facts = FrameworkFacts::default();
-    for symbol in &parsed.symbols {
-        if matches!(
-            symbol.name.as_str(),
-            "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
-        ) {
-            push_route(
-                file,
-                &mut facts,
-                Framework::NextJs,
-                symbol.name.clone(),
-                path_from_nextjs_file(file.relative_path.as_str()),
-                symbol.name.clone(),
-                Vec::new(),
-                symbol.span.clone(),
-                route_offset,
-            );
+
+    if is_nextjs_app_route_file(file.relative_path.as_str()) {
+        for symbol in &parsed.symbols {
+            if is_nextjs_http_method(symbol.name.as_str())
+                && is_exported_nextjs_symbol(file, symbol)
+            {
+                push_route(
+                    file,
+                    &mut facts,
+                    Framework::NextJs,
+                    symbol.name.clone(),
+                    path_from_nextjs_file(file.relative_path.as_str()),
+                    symbol.name.clone(),
+                    Vec::new(),
+                    symbol.span.clone(),
+                    route_offset,
+                );
+            }
+        }
+    } else if is_nextjs_pages_api_file(file.relative_path.as_str()) {
+        if let Some((handler, span)) = nextjs_pages_handler(file, parsed) {
+            for method in nextjs_pages_methods(file) {
+                push_route(
+                    file,
+                    &mut facts,
+                    Framework::NextJs,
+                    method,
+                    path_from_nextjs_file(file.relative_path.as_str()),
+                    handler.clone(),
+                    Vec::new(),
+                    span.clone(),
+                    route_offset,
+                );
+            }
         }
     }
+
     facts
+}
+
+fn is_nextjs_app_route_file(relative_path: &str) -> bool {
+    let path = relative_path.replace('\\', "/");
+    (path.contains("/app/api/") || path.starts_with("app/api/"))
+        && nextjs_route_file_suffix(path.as_str()).is_some()
+}
+
+fn is_nextjs_pages_api_file(relative_path: &str) -> bool {
+    let path = relative_path.replace('\\', "/");
+    (path.contains("/pages/api/") || path.starts_with("pages/api/"))
+        && nextjs_file_extension(path.as_str()).is_some()
+        && !path.ends_with(".d.ts")
+}
+
+fn nextjs_route_file_suffix(path: &str) -> Option<&'static str> {
+    ["/route.ts", "/route.tsx", "/route.js", "/route.jsx"]
+        .into_iter()
+        .find(|suffix| path.ends_with(suffix))
+}
+
+fn nextjs_file_extension(path: &str) -> Option<&'static str> {
+    [".ts", ".tsx", ".js", ".jsx"]
+        .into_iter()
+        .find(|suffix| path.ends_with(suffix))
+}
+
+fn is_nextjs_http_method(method: &str) -> bool {
+    matches!(
+        method,
+        "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS"
+    )
+}
+
+fn is_exported_nextjs_symbol(file: &SourceFile, symbol: &rulepath_parsers::SymbolFact) -> bool {
+    let line = file
+        .text
+        .lines()
+        .nth(symbol.span.start.line.saturating_sub(1))
+        .unwrap_or_default();
+    line.contains("export ")
+        || file.text.contains(&format!("export {{ {} }}", symbol.name))
+        || file.text.contains(&format!("export {{{}}}", symbol.name))
+}
+
+fn nextjs_pages_handler(file: &SourceFile, parsed: &ParsedFile) -> Option<(String, SourceSpan)> {
+    if let Some(symbol) = parsed
+        .symbols
+        .iter()
+        .find(|symbol| is_default_exported_pages_handler(file, symbol.name.as_str()))
+        .or_else(|| {
+            parsed
+                .symbols
+                .iter()
+                .find(|symbol| symbol.name == "handler")
+        })
+        .or_else(|| parsed.symbols.first())
+    {
+        return Some((symbol.name.clone(), symbol.span.clone()));
+    }
+
+    file.text
+        .lines()
+        .enumerate()
+        .find(|(_, line)| line.contains("export default"))
+        .map(|(index, _)| {
+            (
+                "default_handler".to_owned(),
+                SourceSpan::single_line(file.relative_path.as_str(), index + 1),
+            )
+        })
+}
+
+fn is_default_exported_pages_handler(file: &SourceFile, name: &str) -> bool {
+    file.text.lines().any(|line| {
+        let trimmed = line.trim();
+        (trimmed.starts_with("export default") && trimmed.contains(name))
+            || trimmed == format!("export default {name}")
+            || trimmed == format!("export default {name};")
+    })
+}
+
+fn nextjs_pages_methods(file: &SourceFile) -> Vec<String> {
+    let mut methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+        .into_iter()
+        .filter(|method| {
+            file.text.contains("method")
+                && (file.text.contains(&format!("'{method}'"))
+                    || file.text.contains(&format!("\"{method}\"")))
+        })
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if methods.is_empty() {
+        methods.push("ANY".to_owned());
+    }
+    methods
 }
 
 fn extract_django_rest_framework(file: &SourceFile, route_offset: usize) -> FrameworkFacts {
@@ -564,14 +677,22 @@ fn param_expression(framework: Framework) -> String {
 }
 
 fn path_from_nextjs_file(relative_path: &str) -> String {
-    let mut path = relative_path
-        .replace("app/api", "")
-        .replace("pages/api", "")
-        .replace("/route.ts", "")
-        .replace("/route.js", "")
-        .replace(".ts", "")
-        .replace(".js", "");
-    path = path.replace('[', ":").replace(']', "");
+    let mut path = relative_path.replace('\\', "/");
+    if let Some(index) = path.find("app/api") {
+        path = path[index + "app/api".len()..].to_owned();
+        if let Some(suffix) = nextjs_route_file_suffix(path.as_str()) {
+            path.truncate(path.len().saturating_sub(suffix.len()));
+        }
+    } else if let Some(index) = path.find("pages/api") {
+        path = path[index + "pages/api".len()..].to_owned();
+        if let Some(suffix) = nextjs_file_extension(path.as_str()) {
+            path.truncate(path.len().saturating_sub(suffix.len()));
+        }
+        if path.ends_with("/index") {
+            path.truncate(path.len().saturating_sub("/index".len()));
+        }
+    }
+    let path = normalize_nextjs_dynamic_segments(path.as_str());
     if path.is_empty() {
         "/".to_owned()
     } else if path.starts_with('/') {
@@ -579,6 +700,28 @@ fn path_from_nextjs_file(relative_path: &str) -> String {
     } else {
         format!("/{path}")
     }
+}
+
+fn normalize_nextjs_dynamic_segments(path: &str) -> String {
+    path.split('/')
+        .map(|segment| {
+            let normalized = segment
+                .strip_prefix("[[...")
+                .and_then(|rest| rest.strip_suffix("]]"))
+                .or_else(|| {
+                    segment
+                        .strip_prefix("[...")
+                        .and_then(|rest| rest.strip_suffix(']'))
+                })
+                .or_else(|| {
+                    segment
+                        .strip_prefix('[')
+                        .and_then(|rest| rest.strip_suffix(']'))
+                });
+            normalized.map_or_else(|| segment.to_owned(), |name| format!(":{name}"))
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn inferred_django_path(file: &SourceFile) -> String {
@@ -713,6 +856,75 @@ mod tests {
 
         let facts = extract_fastapi(&file, &parsed, 0);
         assert_eq!(facts.routes[0].handler, "update_invoice");
+    }
+
+    #[test]
+    fn nextjs_app_router_discovers_exported_methods_and_dynamic_params() {
+        let file = SourceFile {
+            path: "app/api/invoices/[invoiceId]/route.tsx".into(),
+            relative_path: "app/api/invoices/[invoiceId]/route.tsx".to_owned(),
+            language: Language::TypeScript,
+            text: "export async function PATCH(request: Request, { params }) {\n  return Response.json({ ok: true })\n}\n\nfunction GET() {}\n".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: vec![
+                SymbolFact {
+                    name: "PATCH".to_owned(),
+                    kind: SymbolKind::Function,
+                    span: SourceSpan::single_line("app/api/invoices/[invoiceId]/route.tsx", 1),
+                },
+                SymbolFact {
+                    name: "GET".to_owned(),
+                    kind: SymbolKind::Function,
+                    span: SourceSpan::single_line("app/api/invoices/[invoiceId]/route.tsx", 5),
+                },
+            ],
+            calls: Vec::new(),
+            suppressions: Vec::new(),
+        };
+
+        let facts = extract_nextjs(&file, &parsed, 0);
+        assert_eq!(facts.routes.len(), 1);
+        assert_eq!(facts.routes[0].method, "PATCH");
+        assert_eq!(facts.routes[0].path, "/invoices/:invoiceId");
+        let route_param = facts
+            .sources
+            .iter()
+            .find(|source| source.id.ends_with(":route_param"))
+            .expect("route param source should exist");
+        assert_eq!(route_param.name, "invoiceId");
+        assert_eq!(route_param.expression, "params");
+    }
+
+    #[test]
+    fn nextjs_pages_router_discovers_api_handler_and_method() {
+        let file = SourceFile {
+            path: "pages/api/invoices/[invoiceId].ts".into(),
+            relative_path: "pages/api/invoices/[invoiceId].ts".to_owned(),
+            language: Language::TypeScript,
+            text: "export default async function handler(req, res) {\n  if (req.method === 'PATCH') {\n    return res.json({ ok: true })\n  }\n}\n".to_owned(),
+        };
+        let parsed = ParsedFile {
+            language: Language::TypeScript,
+            file_id: file.relative_path.clone(),
+            imports: Vec::new(),
+            symbols: vec![SymbolFact {
+                name: "handler".to_owned(),
+                kind: SymbolKind::Function,
+                span: SourceSpan::single_line("pages/api/invoices/[invoiceId].ts", 1),
+            }],
+            calls: Vec::new(),
+            suppressions: Vec::new(),
+        };
+
+        let facts = extract_nextjs(&file, &parsed, 0);
+        assert_eq!(facts.routes.len(), 1);
+        assert_eq!(facts.routes[0].method, "PATCH");
+        assert_eq!(facts.routes[0].path, "/invoices/:invoiceId");
+        assert_eq!(facts.routes[0].handler, "handler");
     }
 
     #[test]

--- a/crates/rulepath_lang_typescript/src/lib.rs
+++ b/crates/rulepath_lang_typescript/src/lib.rs
@@ -418,9 +418,10 @@ fn identifier_prefix(text: &str) -> Option<String> {
 fn line_offsets(text: &str) -> Vec<(usize, &str)> {
     let mut lines = Vec::new();
     let mut offset = 0;
-    for line in text.lines() {
+    for raw_line in text.split_inclusive('\n') {
+        let line = raw_line.trim_end_matches('\n').trim_end_matches('\r');
         lines.push((offset, line));
-        offset += line.len() + 1;
+        offset += raw_line.len();
     }
     lines
 }
@@ -553,5 +554,23 @@ router.patch("/:id", routeHandler);
             .iter()
             .any(|call| call.callee == "updateInvoice"));
         assert!(!parsed.calls.is_empty());
+    }
+
+    #[test]
+    fn crlf_sources_keep_symbol_line_numbers() {
+        let parsed = parse("import { prisma } from '@/db'\r\n\r\nexport async function PATCH() {\r\n  await prisma.invoice.update({ where: { id: params.id }, data: body })\r\n}\r\n");
+
+        let patch = parsed
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "PATCH")
+            .expect("PATCH symbol should be parsed");
+        assert_eq!(patch.span.start.line, 3);
+        let update = parsed
+            .calls
+            .iter()
+            .find(|call| call.callee == "prisma.invoice.update")
+            .expect("Prisma call should be parsed");
+        assert_eq!(update.span.start.line, 4);
     }
 }

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -47,6 +47,8 @@ Uncertainty should reduce confidence or produce review hints.
 
 The current analyzer builds a conservative trace index from parser-backed symbols and calls. Framework and data-layer adapters consume those parsed facts through deterministic registries, then dataflow connects route request sources to operations when parsed calls cross from route handlers into service functions.
 
+Next.js extraction covers App Router handlers in `app/api/**/route.{ts,tsx,js,jsx}` and practical Pages Router API handlers in `pages/api/**`. Dynamic segments such as `[invoiceId]`, `[...slug]`, and `[[...slug]]` normalize to route parameter sources, while request body sources use the `request.json()` model for downstream Prisma findings.
+
 Prisma extraction is parser-call backed and recognizes configured client aliases, supported CRUD and bulk methods, nested `where` filters, and `data` mutation payloads while ignoring projection-only `select` and `include` arguments.
 
 SQLAlchemy extraction is parser-call backed for `session.get`, `select`, `update`, `delete`, and `session.execute(...)` wrappers. Object assignment followed by `session.commit()` is modeled as a mutation so request-body field flows are visible to rules.

--- a/docs/testing-fixtures.md
+++ b/docs/testing-fixtures.md
@@ -55,3 +55,5 @@ It should discover an Express route, trace to a Prisma sink, detect request-cont
 The second milestone mirrors that behavior for FastAPI and SQLAlchemy.
 
 The Django/DRF fixture pair verifies Django ORM extraction. The unsafe fixture should emit unscoped resource access for a request-controlled object lookup, while the safe fixture should remain clean because tenant filtering or object permission evidence is recognized.
+
+The Next.js/Prisma/Auth.js fixture pair verifies App Router route extraction, dynamic `[invoiceId]` source IDs, Auth.js evidence labels, and Prisma mutation findings. The unsafe fixture should emit findings for unscoped access, client-controlled mutation data, and missing operation authorization; the safe fixture should remain clean because Auth.js, permission, tenant, and allowlisted field evidence are present.

--- a/fixtures/nextjs_prisma_authjs/unsafe/app/api/invoices/[invoiceId]/route.ts
+++ b/fixtures/nextjs_prisma_authjs/unsafe/app/api/invoices/[invoiceId]/route.ts
@@ -1,6 +1,8 @@
+import { auth } from "@/auth"
 import { prisma } from "@/db"
 
 export async function PATCH(request: Request, { params }: { params: { invoiceId: string } }) {
+  await auth()
   const body = await request.json()
   await prisma.invoice.update({
     where: { id: params.invoiceId },


### PR DESCRIPTION
## Summary

Fixes #7.

This implements the Next.js/Auth.js foundation for Rulepath scans:

- Tightens App Router discovery to exported HTTP methods in `app/api/**/route.{ts,tsx,js,jsx}`.
- Adds practical Pages Router API discovery for `pages/api/**` default handlers, including method inference from `req.method` checks.
- Normalizes Next.js dynamic route segments such as `[invoiceId]`, `[...slug]`, and `[[...slug]]` into route parameter paths and source IDs.
- Keeps request body sources modeled as `request.json()` for Next.js routes so Prisma findings point back to the route file.
- Extends the Next.js/Prisma/Auth.js unsafe fixture to include Auth.js evidence while preserving the intended unsafe Prisma mutation findings.
- Adds CLI fixture assertions for Next.js route IDs, route-file source IDs, call path frames, and `authentication:auth` observed evidence.
- Updates `CHANGELOG.md` and fixture/implementation documentation for the new support.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets`
- `cargo test --locked --workspace`
- `cargo run -p rulepath_cli -- scan fixtures/nextjs_prisma_authjs/unsafe --format json`

The unsafe Next.js fixture emits `INV001`, `INV002`, and `INV003` with route-file source IDs and `authentication:auth` in observed evidence. The safe fixture remains clean.