### PR TITLE
Constrain config-controlled project paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ All notable changes to Rulepath will be documented here.
 - Normalize configured authentication, authorization, scope, transaction, invariant, and idempotency evidence through `rulepath_auth`.
 - Replace one-hop service tracing with an import- and symbol-aware call graph that respects `analysis.service_layer_tracing` and `analysis.max_call_depth`.
 - Fix ORM source-window slicing so non-ASCII source context cannot panic scans.
+- Restrict config-controlled inference output and CI baseline paths to relative paths inside the scan root.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ invariants:
 
 Unknown config keys fail validation. Inline suppressions require a reason by default:
 
+Configured `inference.generated_file` and `ci.baseline_file` values must stay inside the scan root. Use relative paths such as `.rulepath.inferred.yml` or `.rulepath/baseline.json`; absolute paths and `..` segments are rejected.
+
 ```ts
 // rulepath-disable-next-line INV001 -- enforced by requireSuperAdmin middleware above
 const invoice = await prisma.invoice.findUnique({ where: { id } })

--- a/crates/rulepath_cli/src/main.rs
+++ b/crates/rulepath_cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::io::ErrorKind;
+use std::path::{Component, Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{bail, Context, Result};
@@ -134,7 +135,11 @@ fn infer(path: &Path, force: bool) -> Result<ExitCode> {
     let config = rulepath_config::load_project_config(path)?;
     let index = rulepath_workspace::scan_workspace(path, &config)?;
     let inferred = rulepath_infer::infer(&index);
-    let output_path = path.join(&config.raw.inference.generated_file);
+    let output_path = project_output_path(
+        path,
+        &config.raw.inference.generated_file,
+        "inference.generated_file",
+    )?;
     if output_path.exists() && !force {
         bail!(
             "{} already exists; use --force to overwrite",
@@ -179,7 +184,8 @@ fn scan_command(path: &Path, format: OutputFormat, ci: bool) -> Result<ExitCode>
 
 fn baseline_create(path: &Path, force: bool) -> Result<ExitCode> {
     let scan = run_scan(path)?;
-    let baseline_path = path.join(&scan.config.raw.ci.baseline_file);
+    let baseline_path =
+        project_output_path(path, &scan.config.raw.ci.baseline_file, "ci.baseline_file")?;
     if baseline_path.exists() && !force {
         bail!(
             "{} already exists; use --force to overwrite",
@@ -346,7 +352,7 @@ fn matches_ci_policy(diagnostic: &Diagnostic, config: &ResolvedConfig) -> bool {
 }
 
 fn load_baseline(path: &Path, file_name: &str) -> Result<BTreeSet<String>> {
-    let baseline_path = path.join(file_name);
+    let baseline_path = project_input_path(path, file_name, "ci.baseline_file")?;
     if !baseline_path.exists() {
         return Ok(BTreeSet::new());
     }
@@ -360,6 +366,63 @@ fn load_baseline(path: &Path, file_name: &str) -> Result<BTreeSet<String>> {
         .chain(baseline.review_hints)
         .map(|entry| entry.fingerprint)
         .collect())
+}
+
+fn project_output_path(root: &Path, configured: &str, config_key: &str) -> Result<PathBuf> {
+    let path = project_relative_path(root, configured, config_key)?;
+    let parent = path.parent().unwrap_or(root);
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create parent directory for {}", path.display()))?;
+    ensure_canonical_path_under_root(root, parent, config_key)?;
+    match fs::symlink_metadata(&path) {
+        Ok(_) => ensure_canonical_path_under_root(root, &path, config_key)?,
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect configured path {}", path.display()));
+        }
+    }
+    Ok(path)
+}
+
+fn project_input_path(root: &Path, configured: &str, config_key: &str) -> Result<PathBuf> {
+    let path = project_relative_path(root, configured, config_key)?;
+    if path.exists() {
+        ensure_canonical_path_under_root(root, &path, config_key)?;
+    }
+    Ok(path)
+}
+
+fn project_relative_path(root: &Path, configured: &str, config_key: &str) -> Result<PathBuf> {
+    if configured.trim().is_empty() {
+        bail!("{config_key} must not be empty");
+    }
+    let relative = Path::new(configured);
+    if relative.is_absolute() {
+        bail!("{config_key} must be a relative path inside the project root");
+    }
+    for component in relative.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("{config_key} must stay within the project root")
+            }
+        }
+    }
+    Ok(root.join(relative))
+}
+
+fn ensure_canonical_path_under_root(root: &Path, path: &Path, config_key: &str) -> Result<()> {
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("failed to resolve project root {}", root.display()))?;
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("failed to resolve configured path {}", path.display()))?;
+    if !path.starts_with(&root) {
+        bail!("{config_key} must stay within the project root");
+    }
+    Ok(())
 }
 
 fn severity_key(severity: Severity) -> &'static str {

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -306,6 +306,113 @@ fn infer_writes_draft_file_without_policy_enforcement() {
 }
 
 #[test]
+fn infer_rejects_generated_file_outside_project() {
+    let dir = unique_temp_dir("infer-escape");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let escaped_name = format!("rulepath-infer-escape-{}.yml", std::process::id());
+    fs::write(
+        dir.join(".rulepath.yml"),
+        format!("version: 1\ninference:\n  generated_file: ../{escaped_name}\n"),
+    )
+    .expect("test config should be written");
+
+    let output = run_rulepath_in(&dir, &["infer", "."]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("inference.generated_file"));
+    assert!(!dir
+        .parent()
+        .expect("temp dir should have a parent")
+        .join(escaped_name)
+        .exists());
+}
+
+#[test]
+fn infer_rejects_absolute_generated_file() {
+    let dir = unique_temp_dir("infer-absolute");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let absolute = dir.join("outside.yml");
+    let absolute = absolute.to_string_lossy();
+    fs::write(
+        dir.join(".rulepath.yml"),
+        format!("version: 1\ninference:\n  generated_file: '{absolute}'\n"),
+    )
+    .expect("test config should be written");
+
+    let output = run_rulepath_in(&dir, &["infer", "."]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("inference.generated_file"));
+}
+
+#[test]
+fn baseline_rejects_file_outside_project() {
+    let source = fixture_path("fixtures/express_prisma/unsafe");
+    let dir = unique_temp_dir("baseline-escape");
+    copy_dir_all(&source, &dir);
+    let escaped_name = format!("rulepath-baseline-escape-{}.json", std::process::id());
+    fs::write(
+        dir.join(".rulepath.yml"),
+        format!("version: 1\nci:\n  baseline_file: ../{escaped_name}\n"),
+    )
+    .expect("test config should be written");
+
+    let output = run_rulepath_in(&dir, &["baseline", "create", "."]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ci.baseline_file"));
+    assert!(!dir
+        .parent()
+        .expect("temp dir should have a parent")
+        .join(escaped_name)
+        .exists());
+}
+
+#[test]
+fn ci_rejects_baseline_file_outside_project() {
+    let source = fixture_path("fixtures/express_prisma/unsafe");
+    let dir = unique_temp_dir("ci-baseline-escape");
+    copy_dir_all(&source, &dir);
+    fs::write(
+        dir.join(".rulepath.yml"),
+        "version: 1\nci:\n  fail: true\n  baseline_file: ../baseline.json\n",
+    )
+    .expect("test config should be written");
+
+    let output = run_rulepath_in(&dir, &["scan", ".", "--ci"]);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ci.baseline_file"));
+}
+
+#[test]
+fn nested_config_paths_inside_project_are_allowed() {
+    let dir = unique_temp_dir("nested-config-paths");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    fs::write(
+        dir.join(".rulepath.yml"),
+        "version: 1\ninference:\n  generated_file: .rulepath/generated.yml\nci:\n  baseline_file: .rulepath/baseline.json\n",
+    )
+    .expect("test config should be written");
+
+    let infer = run_rulepath_in(&dir, &["infer", "."]);
+    assert!(
+        infer.status.success(),
+        "infer stderr: {}",
+        String::from_utf8_lossy(&infer.stderr)
+    );
+    assert!(dir.join(".rulepath/generated.yml").exists());
+
+    let baseline = run_rulepath_in(&dir, &["baseline", "create", "."]);
+    assert!(
+        baseline.status.success(),
+        "baseline stderr: {}",
+        String::from_utf8_lossy(&baseline.stderr)
+    );
+    assert!(dir.join(".rulepath/baseline.json").exists());
+}
+
+#[test]
 fn ci_failure_respects_baseline() {
     let source = fixture_path("fixtures/express_prisma/unsafe");
     let dir = unique_temp_dir("baseline");

--- a/docs/cli-ci.md
+++ b/docs/cli-ci.md
@@ -36,6 +36,8 @@ Exit behavior:
 - `include_review_hints: false`: review hints do not fail CI.
 - `new_findings_only: true`: baseline entries do not fail CI.
 
+`ci.baseline_file` must be a relative path inside the scan root. Absolute paths and paths containing `..` are rejected for both baseline creation and CI reads.
+
 Suppressions are applied before reporting, baseline creation, and CI failure decisions. When suppression reasons are required, a bare disabling comment is a scan error rather than a hidden finding.
 
 ## JSON Output

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,10 @@ suppressions:
   min_reason_length: 20
 ```
 
+## Configured File Paths
+
+`inference.generated_file` and `ci.baseline_file` must be relative paths inside the scan root. Absolute paths and paths containing `..` fail with a clear config-key error. Nested paths such as `.rulepath/generated.yml` and `.rulepath/baseline.json` are valid; write commands create parent directories inside the project.
+
 ## Resources
 
 Resources define fields that imply tenancy, sensitivity, or server ownership.


### PR DESCRIPTION
## Summary

Fixes #39.

This PR constrains config-controlled file paths so project configuration cannot direct Rulepath to read or write outside the scan root.

## Changes

- Add shared CLI path validation for config-controlled project file paths.
- Reject absolute paths and paths containing `..` for:
  - `inference.generated_file`
  - `ci.baseline_file` during `rulepath baseline create`
  - `ci.baseline_file` during `rulepath scan --ci`
- Preserve valid nested project-local paths such as `.rulepath/generated.yml` and `.rulepath/baseline.json`.
- Create parent directories for valid write targets inside the project root.
- Canonicalize existing write targets so forced writes cannot follow an existing path outside the scan root.
- Add CLI fixture tests covering traversal rejection, absolute-path rejection, CI baseline reads, baseline creation, and valid nested paths.
- Update README, configuration docs, CI docs, and CHANGELOG.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets`
- `cargo test --locked --workspace`
- `cargo build --locked --workspace`