### PR TITLE
Restrict suppression parsing to comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ All notable changes to Rulepath will be documented here.
 - Replace one-hop service tracing with an import- and symbol-aware call graph that respects `analysis.service_layer_tracing` and `analysis.max_call_depth`.
 - Fix ORM source-window slicing so non-ASCII source context cannot panic scans.
 - Restrict config-controlled inference output and CI baseline paths to relative paths inside the scan root.
+- Restrict suppression parsing to recognized TypeScript/JavaScript and Python comments so string literals cannot suppress findings.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ invariants:
     severity: high
 ```
 
-Unknown config keys fail validation. Inline suppressions require a reason by default:
+Unknown config keys fail validation. Inline suppressions require a reason by default and are recognized only in language comments, not string literals:
 
 Configured `inference.generated_file` and `ci.baseline_file` values must stay inside the scan root. Use relative paths such as `.rulepath.inferred.yml` or `.rulepath/baseline.json`; absolute paths and `..` segments are rejected.
 

--- a/crates/rulepath_cli/src/main.rs
+++ b/crates/rulepath_cli/src/main.rs
@@ -249,7 +249,8 @@ fn apply_suppressions(
 fn collect_suppressions(index: &WorkspaceIndex) -> BTreeMap<String, Vec<SuppressionFact>> {
     let mut suppressions = BTreeMap::new();
     for file in &index.files {
-        let file_suppressions = extract_suppressions_from_text(&file.relative_path, &file.text);
+        let file_suppressions =
+            extract_suppressions_from_text(&file.relative_path, &file.text, file.language);
         if !file_suppressions.is_empty() {
             suppressions.insert(file.relative_path.clone(), file_suppressions);
         }

--- a/crates/rulepath_cli/tests/fixture_scans.rs
+++ b/crates/rulepath_cli/tests/fixture_scans.rs
@@ -465,6 +465,50 @@ fn suppression_with_reason_removes_matching_finding() {
 }
 
 #[test]
+fn typescript_string_literal_suppression_marker_does_not_hide_finding() {
+    let source = fixture_path("fixtures/express_prisma/unsafe");
+    let dir = unique_temp_dir("ts-string-suppression");
+    copy_dir_all(&source, &dir);
+    let service_path = dir.join("src/services/invoices.ts");
+    let service = fs::read_to_string(&service_path).expect("service fixture should be readable");
+    fs::write(
+        &service_path,
+        service.replace(
+            "return prisma.invoice.update",
+            "const marker = \"rulepath-disable-next-line INV001 -- ignored string literal suppression\";\n  return prisma.invoice.update",
+        ),
+    )
+    .expect("service fixture should be updated");
+
+    let output = run_rulepath_in(&dir, &["scan", "."]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    assert!(stdout.contains("INV001"));
+}
+
+#[test]
+fn python_string_literal_suppression_marker_does_not_hide_finding() {
+    let source = fixture_path("fixtures/fastapi_sqlalchemy/unsafe");
+    let dir = unique_temp_dir("py-string-suppression");
+    copy_dir_all(&source, &dir);
+    let service_path = dir.join("app/invoice_service.py");
+    let service = fs::read_to_string(&service_path).expect("service fixture should be readable");
+    fs::write(
+        &service_path,
+        service.replace(
+            "invoice = session.get(Invoice, invoice_id)",
+            "marker = \"rulepath-disable-next-line INV001 -- ignored string literal suppression\"\n    invoice = session.get(Invoice, invoice_id)",
+        ),
+    )
+    .expect("service fixture should be updated");
+
+    let output = run_rulepath_in(&dir, &["scan", "."]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    assert!(stdout.contains("INV001"));
+}
+
+#[test]
 fn bare_suppression_fails_policy_validation() {
     let source = fixture_path("fixtures/express_prisma/unsafe");
     let dir = unique_temp_dir("bad-suppression");

--- a/crates/rulepath_lang_python/src/lib.rs
+++ b/crates/rulepath_lang_python/src/lib.rs
@@ -24,7 +24,11 @@ impl LanguageAdapter for PythonAdapter {
             imports: Vec::new(),
             symbols: Vec::new(),
             calls: Vec::new(),
-            suppressions: extract_suppressions_from_text(&file.relative_path, &file.text),
+            suppressions: extract_suppressions_from_text(
+                &file.relative_path,
+                &file.text,
+                file.language,
+            ),
         };
 
         let Some(tree) = parse_tree(file) else {

--- a/crates/rulepath_lang_typescript/src/lib.rs
+++ b/crates/rulepath_lang_typescript/src/lib.rs
@@ -26,7 +26,11 @@ impl LanguageAdapter for TypeScriptAdapter {
             imports: Vec::new(),
             symbols: Vec::new(),
             calls: Vec::new(),
-            suppressions: extract_suppressions_from_text(&file.relative_path, &file.text),
+            suppressions: extract_suppressions_from_text(
+                &file.relative_path,
+                &file.text,
+                file.language,
+            ),
         };
 
         let _parsed_without_panic = parse_with_oxc(file);

--- a/crates/rulepath_parsers/src/lib.rs
+++ b/crates/rulepath_parsers/src/lib.rs
@@ -91,11 +91,157 @@ pub fn position_for_offset(text: &str, offset: usize) -> rulepath_ir::Position {
 }
 
 #[must_use]
-pub fn extract_suppressions_from_text(file_id: &str, text: &str) -> Vec<SuppressionFact> {
-    text.lines()
-        .enumerate()
-        .filter_map(|(index, line)| parse_suppression_line(file_id, index + 1, line))
+pub fn extract_suppressions_from_text(
+    file_id: &str,
+    text: &str,
+    language: Language,
+) -> Vec<SuppressionFact> {
+    comment_lines(text, language)
+        .into_iter()
+        .filter_map(|(line_number, line)| parse_suppression_line(file_id, line_number, &line))
         .collect()
+}
+
+fn comment_lines(text: &str, language: Language) -> Vec<(usize, String)> {
+    match language {
+        Language::Python => python_comment_lines(text),
+        Language::TypeScript => typescript_comment_lines(text),
+    }
+}
+
+fn python_comment_lines(text: &str) -> Vec<(usize, String)> {
+    let mut comments = Vec::new();
+    let mut triple_quote: Option<&str> = None;
+
+    for (index, line) in text.lines().enumerate() {
+        let line_number = index + 1;
+        let bytes = line.as_bytes();
+        let mut cursor = 0;
+
+        while cursor < bytes.len() {
+            if let Some(delimiter) = triple_quote {
+                if bytes_start_with(bytes, cursor, delimiter.as_bytes()) {
+                    triple_quote = None;
+                    cursor += delimiter.len();
+                } else {
+                    cursor += 1;
+                }
+                continue;
+            }
+
+            match bytes[cursor] {
+                b'#' => {
+                    comments.push((line_number, line[cursor + 1..].to_owned()));
+                    break;
+                }
+                b'\'' | b'"' => {
+                    let quote = bytes[cursor];
+                    if line[cursor..].starts_with(if quote == b'\'' { "'''" } else { "\"\"\"" }) {
+                        triple_quote = Some(if quote == b'\'' { "'''" } else { "\"\"\"" });
+                        cursor += 3;
+                    } else {
+                        cursor += 1;
+                        while cursor < bytes.len() {
+                            if bytes[cursor] == b'\\' {
+                                cursor += 2;
+                            } else if bytes[cursor] == quote {
+                                cursor += 1;
+                                break;
+                            } else {
+                                cursor += 1;
+                            }
+                        }
+                    }
+                }
+                _ => cursor += 1,
+            }
+        }
+    }
+
+    comments
+}
+
+fn bytes_start_with(bytes: &[u8], cursor: usize, expected: &[u8]) -> bool {
+    bytes
+        .get(cursor..cursor.saturating_add(expected.len()))
+        .is_some_and(|candidate| candidate == expected)
+}
+
+fn typescript_comment_lines(text: &str) -> Vec<(usize, String)> {
+    let bytes = text.as_bytes();
+    let mut comments = Vec::new();
+    let mut cursor = 0;
+    let mut line_number = 1;
+
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'\n' => {
+                line_number += 1;
+                cursor += 1;
+            }
+            b'\'' | b'"' => {
+                cursor = skip_quoted_text(bytes, cursor, bytes[cursor], &mut line_number);
+            }
+            b'`' => {
+                cursor = skip_quoted_text(bytes, cursor, b'`', &mut line_number);
+            }
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => {
+                let start = cursor + 2;
+                let end = text[start..]
+                    .find('\n')
+                    .map_or(text.len(), |offset| start + offset);
+                comments.push((line_number, text[start..end].to_owned()));
+                cursor = end;
+            }
+            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                cursor += 2;
+                let mut line_start = cursor;
+                while cursor < bytes.len() {
+                    if bytes[cursor] == b'*' && bytes.get(cursor + 1) == Some(&b'/') {
+                        comments.push((line_number, text[line_start..cursor].to_owned()));
+                        cursor += 2;
+                        break;
+                    }
+                    if bytes[cursor] == b'\n' {
+                        comments.push((line_number, text[line_start..cursor].to_owned()));
+                        line_number += 1;
+                        cursor += 1;
+                        line_start = cursor;
+                    } else {
+                        cursor += 1;
+                    }
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+
+    comments
+}
+
+fn skip_quoted_text(
+    bytes: &[u8],
+    mut cursor: usize,
+    delimiter: u8,
+    line_number: &mut usize,
+) -> usize {
+    cursor += 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            if bytes.get(cursor + 1) == Some(&b'\n') {
+                *line_number += 1;
+            }
+            cursor += 2;
+        } else if bytes[cursor] == delimiter {
+            return cursor + 1;
+        } else {
+            if bytes[cursor] == b'\n' {
+                *line_number += 1;
+            }
+            cursor += 1;
+        }
+    }
+    cursor
 }
 
 fn parse_suppression_line(
@@ -139,8 +285,46 @@ mod tests {
     #[test]
     fn parses_suppression_reason() {
         let text = "// rulepath-disable-next-line INV001 -- tenant scope is enforced above";
-        let suppressions = extract_suppressions_from_text("file.ts", text);
+        let suppressions = extract_suppressions_from_text("file.ts", text, Language::TypeScript);
         assert_eq!(suppressions[0].rule_id, "INV001");
         assert!(suppressions[0].reason.is_some());
+    }
+
+    #[test]
+    fn ignores_typescript_string_literals() {
+        let text = r#"
+const marker = "rulepath-disable-next-line INV001 -- ignored in string";
+const other = '// rulepath-disable-line INV002 -- ignored in string';
+// rulepath-disable-line INV003 -- parsed from comment
+"#;
+        let suppressions = extract_suppressions_from_text("file.ts", text, Language::TypeScript);
+
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].rule_id, "INV003");
+    }
+
+    #[test]
+    fn ignores_python_string_literals() {
+        let text = r#"
+marker = "rulepath-disable-next-line INV001 -- ignored in string"
+other = '# rulepath-disable-line INV002 -- ignored in string'
+# rulepath-disable-line INV003 -- parsed from comment
+"#;
+        let suppressions = extract_suppressions_from_text("file.py", text, Language::Python);
+
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].rule_id, "INV003");
+    }
+
+    #[test]
+    fn ignores_python_triple_quoted_strings_with_non_ascii_content() {
+        let text = r#"
+marker = """café rulepath-disable-next-line INV001 -- ignored in string"""
+# rulepath-disable-line INV002 -- parsed from comment
+"#;
+        let suppressions = extract_suppressions_from_text("file.py", text, Language::Python);
+
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].rule_id, "INV002");
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,8 @@ rulepath-disable RULE_ID -- reason
 rulepath-enable RULE_ID
 ```
 
+Suppression markers are recognized only in language comments: `//` and `/* ... */` for TypeScript/JavaScript, and `#` for Python. Markers inside string literals are ignored.
+
 When `suppressions.require_reason` is true, disabling comments must include a reason after `--`.
 
 Suppressed diagnostics are removed before text, JSON, SARIF, baseline, and CI output. Bare or too-short suppression reasons fail the scan when the policy requires reasons.


### PR DESCRIPTION
## Summary

Fixes #40.

This PR prevents suppression markers embedded in string literals from being treated as active Rulepath suppressions. Suppression extraction now first identifies language comment text, then parses `rulepath-` markers only from those comment regions.

## Changes

- Update shared suppression extraction to require recognized language comments:
  - TypeScript/JavaScript: `//` and `/* ... */`
  - Python: `#`
- Skip TypeScript/JavaScript single-quoted, double-quoted, and template string content while scanning for comments.
- Skip Python single-quoted, double-quoted, and triple-quoted string content while scanning for `#` comments.
- Pass source language into suppression extraction from the CLI and language adapters.
- Add parser regression tests for TypeScript and Python string literals, including a UTF-8 triple-quoted Python string case.
- Add end-to-end CLI regressions proving TypeScript and Python string markers do not suppress real findings.
- Update README, configuration docs, and CHANGELOG to document that suppressions are only recognized in comments.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets`
- `cargo test --locked --workspace`
- `cargo build --locked --workspace`