### PR TITLE
Include sink span in diagnostic fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ All notable changes to Rulepath will be documented here.
 - Fix ORM source-window slicing so non-ASCII source context cannot panic scans.
 - Restrict config-controlled inference output and CI baseline paths to relative paths inside the scan root.
 - Restrict suppression parsing to recognized TypeScript/JavaScript and Python comments so string literals cannot suppress findings.
+- Include sink identity and primary span location in diagnostic fingerprints; regenerate baselines after upgrading.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Review hints: 1
   [MEDIUM] HINT003 Possible workflow state transition
 ```
 
-CI is advisory by default. `rulepath scan . --ci` exits nonzero only when `.rulepath.yml` sets `ci.fail: true` and an unsuppressed, non-baselined finding matches `ci.fail_on`.
+CI is advisory by default. `rulepath scan . --ci` exits nonzero only when `.rulepath.yml` sets `ci.fail: true` and an unsuppressed, non-baselined finding matches `ci.fail_on`. Baseline fingerprints include sink identity and primary span location, so regenerate baselines after upgrades that change fingerprint inputs.
 
 ## Documentation
 

--- a/crates/rulepath_rules/src/lib.rs
+++ b/crates/rulepath_rules/src/lib.rs
@@ -500,6 +500,8 @@ fn diagnostic(
         .collect::<Vec<_>>();
     source_ids.sort();
     source_ids.dedup();
+    let span_line = operation.span.start.line.to_string();
+    let span_column = operation.span.start.column.to_string();
 
     Diagnostic {
         kind,
@@ -524,10 +526,13 @@ fn diagnostic(
         fingerprint: fingerprint(&[
             rule_id,
             route_id.unwrap_or("no-route"),
+            &operation.id,
             &operation.resource,
             &format!("{:?}", operation.operation),
             &operation.method,
             &operation.span.file_id,
+            &span_line,
+            &span_column,
         ]),
     }
 }
@@ -601,9 +606,115 @@ fn observed_labels(evidence: &[&EvidenceFact]) -> Vec<String> {
 mod tests {
     use super::*;
 
+    use rulepath_config::{ResourceConfig, RulepathConfig};
+    use rulepath_ir::{
+        CallFrame, DataLayer, FilterFact, Framework, Language, Position, RouteFact, SourceSpan,
+    };
+
     #[test]
     fn explanations_cover_core_rule() {
         let explanation = explain("INV001").expect("INV001 explanation should exist");
         assert_eq!(explanation.title, "Unscoped resource access");
+    }
+
+    #[test]
+    fn same_shaped_findings_at_different_sinks_have_distinct_fingerprints() {
+        let config = config_with_invoice_resource();
+        let ir = ProjectIr {
+            routes: vec![RouteFact {
+                id: "route:express:patch:/invoices/:id".to_owned(),
+                framework: Framework::Express,
+                language: Language::TypeScript,
+                method: "PATCH".to_owned(),
+                path: "/invoices/:id".to_owned(),
+                handler: "updateInvoice".to_owned(),
+                span: span(1, 1),
+                middleware: Vec::new(),
+                sources: vec!["source:route-param".to_owned()],
+            }],
+            operations: vec![
+                operation("sink:prisma.invoice.update:src/invoices.ts:10", 10),
+                operation("sink:prisma.invoice.update:src/invoices.ts:20", 20),
+            ],
+            call_paths: vec![
+                call_path(
+                    "callpath:route:express:patch:/invoices/:id:sink:10",
+                    "sink:prisma.invoice.update:src/invoices.ts:10",
+                ),
+                call_path(
+                    "callpath:route:express:patch:/invoices/:id:sink:20",
+                    "sink:prisma.invoice.update:src/invoices.ts:20",
+                ),
+            ],
+            ..ProjectIr::default()
+        };
+
+        let diagnostics = evaluate(&ir, &config);
+        let inv001 = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_id == "INV001")
+            .collect::<Vec<_>>();
+        let repeated = evaluate(&ir, &config);
+        let repeated_inv001 = repeated
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_id == "INV001")
+            .collect::<Vec<_>>();
+
+        assert_eq!(inv001.len(), 2);
+        assert_ne!(inv001[0].fingerprint, inv001[1].fingerprint);
+        assert_eq!(inv001, repeated_inv001);
+    }
+
+    fn config_with_invoice_resource() -> ResolvedConfig {
+        let mut raw = RulepathConfig::default();
+        raw.resources.insert(
+            "Invoice".to_owned(),
+            ResourceConfig {
+                tenant_fields: vec!["tenant_id".to_owned()],
+                sensitive_fields: Vec::new(),
+                server_owned_fields: Vec::new(),
+            },
+        );
+        ResolvedConfig::new(raw)
+    }
+
+    fn operation(id: &str, line: usize) -> OperationFact {
+        OperationFact {
+            id: id.to_owned(),
+            data_layer: DataLayer::Prisma,
+            resource: "Invoice".to_owned(),
+            operation: OperationType::Update,
+            method: "update".to_owned(),
+            filters: vec![FilterFact {
+                field: "id".to_owned(),
+                value: "invoiceId".to_owned(),
+                source_id: Some("source:route-param".to_owned()),
+            }],
+            mutation_fields: Vec::new(),
+            bulk: false,
+            span: span(line, 3),
+        }
+    }
+
+    fn call_path(id: &str, sink_id: &str) -> CallPath {
+        CallPath {
+            id: id.to_owned(),
+            route_id: "route:express:patch:/invoices/:id".to_owned(),
+            sink_id: sink_id.to_owned(),
+            frames: vec![CallFrame {
+                function: "updateInvoice".to_owned(),
+                file: "src/invoices.ts".to_owned(),
+                line: 1,
+            }],
+            confidence: Confidence::High,
+        }
+    }
+
+    fn span(line: usize, column: usize) -> SourceSpan {
+        SourceSpan {
+            file_id: "src/invoices.ts".to_owned(),
+            start: Position::new(line, column),
+            end: Position::new(line, column + 1),
+        }
     }
 }

--- a/docs/cli-ci.md
+++ b/docs/cli-ci.md
@@ -38,6 +38,8 @@ Exit behavior:
 
 `ci.baseline_file` must be a relative path inside the scan root. Absolute paths and paths containing `..` are rejected for both baseline creation and CI reads.
 
+Baseline fingerprints include the rule, route, sink identity, resource, operation, method, file, and primary span start. Regenerate baselines after upgrades that change fingerprint inputs.
+
 Suppressions are applied before reporting, baseline creation, and CI failure decisions. When suppression reasons are required, a bare disabling comment is a scan error rather than a hidden finding.
 
 ## JSON Output


### PR DESCRIPTION
## Summary

Fixes #41.

This PR makes diagnostic fingerprints distinguish same-shaped findings that occur in the same file at different sinks. The fingerprint now includes the sink operation ID and primary span start location in addition to the existing rule, route, resource, operation, method, and file components.

## Changes

- Add sink operation identity to diagnostic fingerprint inputs.
- Add primary span start line and column to diagnostic fingerprint inputs.
- Preserve deterministic fingerprint behavior for repeated evaluations.
- Add a rule unit test with two same-shaped INV001 findings in one file at different sink spans and assert distinct, repeatable fingerprints.
- Update README and CI docs to document fingerprint inputs and baseline regeneration expectations.
- Update CHANGELOG with the baseline fingerprint change.

## Baseline compatibility

Because fingerprint inputs changed, existing baseline files should be regenerated after this change lands.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets`
- `cargo test --locked --workspace`
- `cargo build --locked --workspace`